### PR TITLE
Display raw value for price parameter

### DIFF
--- a/Sources/IAPView/NotificationHistoryTableView.swift
+++ b/Sources/IAPView/NotificationHistoryTableView.swift
@@ -50,7 +50,7 @@ struct NotificationHistoryTableView: View {
         }
         .width(ideal: 160)
         TableColumn("price") {
-            CellText($0.transactionInfo?.price.map { $0 / 1000 }?.description)
+            CellText($0.transactionInfo?.price?.description)
         }
         .width(ideal: 60)
         TableColumn("currency") {

--- a/Sources/IAPView/SubscriptionStatusTableView.swift
+++ b/Sources/IAPView/SubscriptionStatusTableView.swift
@@ -47,7 +47,7 @@ struct SubscriptionStatusTableView: View {
         }
         .width(ideal: 160)
         TableColumn("price") {
-            CellText($0.transaction?.price.map { $0 / 1000 }?.description)
+            CellText($0.transaction?.price?.description)
         }
         .width(ideal: 60)
         TableColumn("currency") {

--- a/Sources/IAPView/TransactionHistoryTableView.swift
+++ b/Sources/IAPView/TransactionHistoryTableView.swift
@@ -35,7 +35,7 @@ struct TransactionHistoryTableView: View {
         }
         .width(ideal: 160)
         TableColumn("price") {
-            CellText($0.price.map { $0 / 1000 }?.description)
+            CellText($0.price?.description)
         }
         .width(ideal: 60)
         TableColumn("currency") {


### PR DESCRIPTION
## WHY

- https://developer.apple.com/documentation/appstoreserverapi/price

> This value represents the price of the in-app purchase or subscription offer that you configured in App Store Connect multiplied by 1000, to result in an integer value.

So it is easier to see the original value if it is converted, but since it is an API Viewer, the original value is given priority.