### PR TITLE
Accept enter keyboard and highlight retry button when parameters are staled

### DIFF
--- a/Sources/IAPModel/IAPModel.swift
+++ b/Sources/IAPModel/IAPModel.swift
@@ -31,10 +31,14 @@ public final class IAPModel {
         LoadingViewState<SubscriptionStatus> = .waiting
 
     // MARK: - Shared State parameters
+    /// whether highlighted retry button
+    public var isStaledParameters = false
     public var transactionID = ""
     public var environment: ServerEnvironment = .sandbox
 
     // MARK: - Notification History parameters
+    /// whether highlighted notification history retry button
+    public var isNotificationHistoryStaledParameters = false
     public var notificationHistoryTransactionID = ""
     public var notificationStartDate = Calendar.current.date(
         byAdding: .weekOfMonth, value: -2, to: .now)!

--- a/Sources/IAPView/NotificationHistoryView.swift
+++ b/Sources/IAPView/NotificationHistoryView.swift
@@ -153,16 +153,34 @@ struct NotificationHistoryView: View {
             ToolbarItem {
                 Button {
                     Task {
+                        model.isNotificationHistoryStaledParameters = false
                         await model.execute(action: .clearNotificationHistoryError)
                     }
                 } label: {
-                    Image(systemName: "arrow.clockwise")
+                    Image(systemName: "arrow.counterclockwise")
+                        .bold()
+                        .foregroundStyle(
+                            model.isNotificationHistoryStaledParameters
+                                ? .orange : .gray.opacity(0.7))
                 }
                 .help("Retry")
             }
         }
         .onChange(of: model.environment) { _, _ in
             Task {
+                await model.execute(action: .clearNotificationHistoryError)
+            }
+        }
+        .onChange(of: [
+            model.notificationHistoryTransactionID, model.notificationStartDate.formatted(),
+            model.notificationEndDate.formatted(),
+        ]) { (oldValue, newValue) in
+            guard oldValue != newValue else { return }
+            model.isNotificationHistoryStaledParameters = true
+        }
+        .onSubmit {
+            Task {
+                model.isNotificationHistoryStaledParameters = false
                 await model.execute(action: .clearNotificationHistoryError)
             }
         }

--- a/Sources/IAPView/SubscriptionStatusView.swift
+++ b/Sources/IAPView/SubscriptionStatusView.swift
@@ -89,16 +89,29 @@ struct SubscriptionStatusView: View {
             ToolbarItem {
                 Button {
                     Task {
+                        model.isStaledParameters = false
                         await model.execute(action: .clearAllSubscriptionStatusesError)
                     }
                 } label: {
-                    Image(systemName: "arrow.clockwise")
+                    Image(systemName: "arrow.counterclockwise")
+                        .bold()
+                        .foregroundStyle(model.isStaledParameters ? .orange : .gray.opacity(0.7))
                 }
                 .help("Retry")
             }
         }
         .onChange(of: model.environment) { _, _ in
             Task {
+                await model.execute(action: .clearAllSubscriptionStatusesError)
+            }
+        }
+        .onChange(of: model.transactionID) { (oldValue, newValue) in
+            guard oldValue != newValue, !oldValue.isEmpty else { return }
+            model.isStaledParameters = true
+        }
+        .onSubmit {
+            Task {
+                model.isStaledParameters = false
                 await model.execute(action: .clearAllSubscriptionStatusesError)
             }
         }

--- a/Sources/IAPView/TransactionHistoryView.swift
+++ b/Sources/IAPView/TransactionHistoryView.swift
@@ -156,16 +156,34 @@ struct TransactionHistoryView: View {
             ToolbarItem {
                 Button {
                     Task {
+                        model.isStaledParameters = false
                         await model.execute(action: .clearTransactionHistoryError)
                     }
                 } label: {
-                    Image(systemName: "arrow.clockwise")
+                    Image(systemName: "arrow.counterclockwise")
+                        .bold()
+                        .foregroundStyle(model.isStaledParameters ? .orange : .gray.opacity(0.7))
                 }
                 .help("Retry")
             }
         }
         .onChange(of: model.environment) { _, _ in
             Task {
+                await model.execute(action: .clearTransactionHistoryError)
+            }
+        }
+        .onChange(of: model.transactionID) { (oldValue, newValue) in
+            guard oldValue != newValue, !oldValue.isEmpty else { return }
+            model.isStaledParameters = true
+        }
+        .onChange(of: [model.transactionStartDate, model.transactionEndDate]) {
+            (oldValue, newValue) in
+            guard oldValue != newValue else { return }
+            model.isStaledParameters = true
+        }
+        .onSubmit {
+            Task {
+                model.isStaledParameters = false
                 await model.execute(action: .clearTransactionHistoryError)
             }
         }


### PR DESCRIPTION
## WHY

- Some time, parameters and results are different. If this state is found, display `should refresh` state in retry button.

## WHAT

- Support enter key action (when transactionID is changed and enter, refresh smoothly)
- Highlight retry button when transactionID, startDate or endDate parameters are changed.
  - also change refresh icon