### PR TITLE
Support consumption request and request reason column

### DIFF
--- a/Sources/IAPInterface/Model/NotificationHistoryItem+.swift
+++ b/Sources/IAPInterface/Model/NotificationHistoryItem+.swift
@@ -34,6 +34,8 @@ extension NotificationHistoryItem {
         case (.revoke, _), (.expired, .voluntary), (.expired, .priceIncrease),
             (.expired, .billingRetry):
             return "slash.circle"
+        case (.consumptionRequest, _):
+            return "questionmark.circle.fill"
         case (.externalPurchaseToken, .unreported):
             return "creditcard.fill"
         case (.test, _):

--- a/Sources/IAPInterface/Model/NotificationHistoryModel.swift
+++ b/Sources/IAPInterface/Model/NotificationHistoryModel.swift
@@ -47,6 +47,8 @@ public struct NotificationHistoryItem: Identifiable, Codable, Hashable {
     public let transactionInfo: JWSTransactionDecodedPayload?
     // MARK: - RenewalInfo
     public let renewalInfo: JWSRenewalInfoDecodedPayload?
+    // MARK: - ConsumptionRequestReason
+    public let consumptionRequestReason: ConsumptionRequestReason?
     // MARK: - ExternalPurchaseToken
     public let externalPurchaseToken: ExternalPurchaseToken?
 
@@ -62,6 +64,7 @@ public struct NotificationHistoryItem: Identifiable, Codable, Hashable {
         self.signedDate = payload.signedDate
         self.transactionInfo = transactionInfo
         self.renewalInfo = renewalInfo
+        self.consumptionRequestReason = payload.data?.consumptionRequestReason
         self.externalPurchaseToken = payload.externalPurchaseToken
     }
 }

--- a/Sources/IAPView/NotificationHistoryTableView.swift
+++ b/Sources/IAPView/NotificationHistoryTableView.swift
@@ -80,6 +80,10 @@ struct NotificationHistoryTableView: View {
     }
     @TableColumnBuilder<NotificationHistoryItem, Never>
     var externalColumns: some TableColumnContent<NotificationHistoryItem, Never> {
+        TableColumn("consumptionRequestReason") {
+            CellText($0.consumptionRequestReason?.rawValue)
+        }
+        .width(ideal: 160)
         TableColumn("externalPurchaseId") {
             CellText($0.externalPurchaseToken?.externalPurchaseId)
         }

--- a/Sources/IAPView/Resources/Localizable.xcstrings
+++ b/Sources/IAPView/Resources/Localizable.xcstrings
@@ -117,6 +117,9 @@
     "com.shimastripe.XXXXXX" : {
 
     },
+    "consumptionRequestReason" : {
+
+    },
     "currency" : {
 
     },


### PR DESCRIPTION
## WHY

- Added the [consumptionRequestReason](https://developer.apple.com/documentation/appstoreservernotifications/consumptionrequestreason) to the [data](https://developer.apple.com/documentation/appstoreservernotifications/data) object.
- The CONSUMPTION_REQUEST [notificationType](https://developer.apple.com/documentation/appstoreservernotifications/notificationtype) added notifications for refund requests for auto-renewable subscription.
 - https://developer.apple.com/documentation/appstoreservernotifications/app_store_server_notifications_changelog#4337151