### PR TITLE
Fix concurrency warnings

### DIFF
--- a/Sources/IAPClient/AppStoreServerClient.swift
+++ b/Sources/IAPClient/AppStoreServerClient.swift
@@ -11,7 +11,7 @@ import Foundation
 import IAPInterface
 
 extension AppStoreServerClient: DependencyKey {
-    public static var liveValue: AppStoreServerClient {
+    public static let liveValue: AppStoreServerClient = {
         .init(
             fetchNotificationHistory: {
                 startDate, endDate, transactionID, paginationToken, credential, rootCertificate,
@@ -129,7 +129,9 @@ extension AppStoreServerClient: DependencyKey {
                                 signedTransaction))
                     }
 
-                    items = items.sorted(by: { ($0.purchaseDate ?? .distantPast) < ($1.purchaseDate ?? .distantPast) })
+                    items = items.sorted(by: {
+                        ($0.purchaseDate ?? .distantPast) < ($1.purchaseDate ?? .distantPast)
+                    })
 
                     return .init(
                         revision: response.revision, hasMore: response.hasMore,
@@ -210,5 +212,5 @@ extension AppStoreServerClient: DependencyKey {
                         causedBy: causedBy)
                 }
             })
-    }
+    }()
 }

--- a/Sources/IAPClient/CredentialClient.swift
+++ b/Sources/IAPClient/CredentialClient.swift
@@ -12,10 +12,11 @@ import KeychainAccess
 
 extension CredentialClient: DependencyKey {
 
-    public static var liveValue: IAPInterface.CredentialClient {
+    public static let liveValue: IAPInterface.CredentialClient = {
         let keychain = Keychain()
         let modelKey = "appleServerAPICredential"
 
+        @Sendable
         func get() throws -> Model? {
             guard let data = try keychain.getData(modelKey) else { return nil }
             let decoder = JSONDecoder()
@@ -23,6 +24,7 @@ extension CredentialClient: DependencyKey {
             return try decoder.decode(Model.self, from: data)
         }
 
+        @Sendable
         func set(
             bundleID: String, issuerID: String, keyID: String, appAppleID: Int,
             privateKeyFileURL: URL
@@ -49,6 +51,7 @@ extension CredentialClient: DependencyKey {
             try keychain.set(data, key: modelKey)
         }
 
+        @Sendable
         func remove() throws {
             try keychain.remove(modelKey)
         }
@@ -65,5 +68,5 @@ extension CredentialClient: DependencyKey {
             remove: {
                 try remove()
             })
-    }
+    }()
 }

--- a/Sources/IAPClient/RootCertificateClient.swift
+++ b/Sources/IAPClient/RootCertificateClient.swift
@@ -13,11 +13,12 @@ import IAPInterface
 import KeychainAccess
 
 extension RootCertificateClient: DependencyKey {
-    public static var liveValue: RootCertificateClient {
+    public static let liveValue: RootCertificateClient = {
 
         let keychain = Keychain()
         let modelKey = "appleRootCertificate"
 
+        @Sendable
         func fetch() async throws -> Data {
             let request = HTTPRequest(
                 method: .get, scheme: "https", authority: "www.apple.com",
@@ -29,14 +30,17 @@ extension RootCertificateClient: DependencyKey {
             return responseBody
         }
 
+        @Sendable
         func get() throws -> Model? {
             try keychain.getData(modelKey)
         }
 
+        @Sendable
         func set(model: Model) throws {
             try keychain.set(model, key: modelKey)
         }
 
+        @Sendable
         func remove() throws {
             try keychain.remove(modelKey)
         }
@@ -53,5 +57,5 @@ extension RootCertificateClient: DependencyKey {
             remove: {
                 try remove()
             })
-    }
+    }()
 }

--- a/Sources/IAPInterface/AppStoreServerClientInterface.swift
+++ b/Sources/IAPInterface/AppStoreServerClientInterface.swift
@@ -10,7 +10,7 @@ import DependenciesMacros
 import Foundation
 
 @DependencyClient
-public struct AppStoreServerClient {
+public struct AppStoreServerClient: Sendable {
 
     public enum AppStoreServerClientError: LocalizedError {
         case requestError(
@@ -28,6 +28,7 @@ public struct AppStoreServerClient {
     }
 
     public var fetchNotificationHistory:
+        @Sendable
         (
             _ startDate: Date, _ endDate: Date, _ transactionID: String?,
             _ paginationToken: String?,
@@ -36,6 +37,7 @@ public struct AppStoreServerClient {
             async throws -> NotificationHistoryModel
 
     public var fetchTransactionHistory:
+        @Sendable
         (
             _ startDate: Date, _ endDate: Date, _ transactionID: String,
             _ revision: String?, _ credential: IAPEnvironment, _ rootCertificate: Data,
@@ -43,6 +45,7 @@ public struct AppStoreServerClient {
         ) async throws -> TransactionHistory
 
     public var fetchAllSubscriptionStatuses:
+        @Sendable
         (
             _ transactionID: String, _ credential: IAPEnvironment, _ rootCertificate: Data,
             _ environment: ServerEnvironment
@@ -51,9 +54,9 @@ public struct AppStoreServerClient {
 
 // MARK: Implementation
 extension AppStoreServerClient: TestDependencyKey {
-    public static var testValue = Self()
-    public static var previewValue: AppStoreServerClient = {
-        var makeDate: (_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date? =
+    public static let testValue = Self()
+    public static let previewValue: AppStoreServerClient = {
+        let makeDate: (_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date? =
             {
                 (year, month, day, hour, minute) in
                 Calendar.current.date(

--- a/Sources/IAPInterface/CredentialClientInterface.swift
+++ b/Sources/IAPInterface/CredentialClientInterface.swift
@@ -10,7 +10,7 @@ import DependenciesMacros
 import Foundation
 
 @DependencyClient
-public struct CredentialClient {
+public struct CredentialClient: Sendable {
 
     public typealias Model = IAPEnvironment
 
@@ -20,21 +20,22 @@ public struct CredentialClient {
         case notAcceptableStatus(Int)
     }
 
-    public var get: () async throws -> Model?
+    public var get: @Sendable () async throws -> Model?
     public var set:
+        @Sendable
         (
             _ bundleID: String, _ issuerID: String, _ keyID: String, _ appAppleID: Int,
             _ privateKeyFileURL: URL
         )
             async throws -> Void
-    public var remove: () async throws -> Void
+    public var remove: @Sendable () async throws -> Void
 }
 
 // MARK: Implementation
 
 extension CredentialClient: TestDependencyKey {
-    public static var testValue = Self()
-    public static var previewValue: CredentialClient = .init {
+    public static let testValue = Self()
+    public static let previewValue: CredentialClient = .init {
         .init(bundleID: "", issuerID: "", keyID: "", appAppleID: 0, encodedKey: "")
     } set: { _, _, _, _, _ in
         unimplemented()

--- a/Sources/IAPInterface/Model/NotificationHistoryItem+.swift
+++ b/Sources/IAPInterface/Model/NotificationHistoryItem+.swift
@@ -16,7 +16,8 @@ extension NotificationHistoryItem {
             return "play.fill"
         case (.subscribed, .resubscribe), (.offerRedeemed, .resubscribe):
             return "memories"
-        case (.didRenew, nil), (.didChangeRenewalPref, .upgrade), (.renewalExtended, _), (.renewalExtension, _),
+        case (.didRenew, nil), (.didChangeRenewalPref, .upgrade), (.renewalExtended, _),
+            (.renewalExtension, _),
             (.priceIncrease, .accepted):
             return "arrow.triangle.2.circlepath"
         case (.didChangeRenewalPref, .downgrade), (.didChangeRenewalPref, nil),
@@ -57,7 +58,8 @@ extension NotificationHistoryItem {
     public var eventColor: Color {
         switch (notificationType, subType) {
         case (.subscribed, _), (.offerRedeemed, _), (.didRenew, _), (.renewalExtended, _),
-            (.renewalExtension, .summary), (.didChangeRenewalPref, .upgrade), (.refundReversed, _), (.oneTimeCharge, _):
+            (.renewalExtension, .summary), (.didChangeRenewalPref, .upgrade), (.refundReversed, _),
+            (.oneTimeCharge, _):
             return .green
         case (.didFailToRenew, .gracePeriod):
             return .blue

--- a/Sources/IAPInterface/RootCertificateClientInterface.swift
+++ b/Sources/IAPInterface/RootCertificateClientInterface.swift
@@ -10,7 +10,7 @@ import DependenciesMacros
 import Foundation
 
 @DependencyClient
-public struct RootCertificateClient {
+public struct RootCertificateClient: Sendable {
 
     public typealias Model = Data
 
@@ -18,17 +18,17 @@ public struct RootCertificateClient {
         case notAcceptableStatus(Int)
     }
 
-    public var fetch: () async throws -> Model
+    public var fetch: @Sendable () async throws -> Model
 
-    public var get: () async throws -> Model?
-    public var remove: () async throws -> Void
+    public var get: @Sendable () async throws -> Model?
+    public var remove: @Sendable () async throws -> Void
 }
 
 // MARK: Implementation
 
 extension RootCertificateClient: TestDependencyKey {
-    public static var testValue = Self()
-    public static var previewValue: RootCertificateClient = .init(
+    public static let testValue = Self()
+    public static let previewValue: RootCertificateClient = .init(
         fetch: {
             unimplemented()
         },

--- a/Sources/IAPView/Resources/Localizable.xcstrings
+++ b/Sources/IAPView/Resources/Localizable.xcstrings
@@ -129,6 +129,9 @@
     "Download AppleRootCA-G3.cer" : {
 
     },
+    "eligibleWinBackOfferIds" : {
+
+    },
     "EndDate" : {
 
     },
@@ -280,6 +283,9 @@
 
     },
     "renewalInfo signedDate" : {
+
+    },
+    "renewalPrice" : {
 
     },
     "Retrieves 200 items for a given period of time" : {


### PR DESCRIPTION
## WHY

- Concurrently-executed local function 'XXX()' must be marked as '@Sendable'; this is an error in Swift 6
- Static property 'testValue' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6

Fix these warnings.

