### PR TITLE
Follow recent App Store Server API updates

### DIFF
--- a/Sources/IAPInterface/Model/AppData+.swift
+++ b/Sources/IAPInterface/Model/AppData+.swift
@@ -1,0 +1,10 @@
+//
+//  AppData+.swift
+//  InAppPurchaseViewer
+//
+//  Created by Codex on 2026/05/09.
+//
+
+import AppStoreServerLibrary  // For Model
+
+public typealias AppData = AppStoreServerLibrary.AppData

--- a/Sources/IAPInterface/Model/NotificationFilterOption.swift
+++ b/Sources/IAPInterface/Model/NotificationFilterOption.swift
@@ -93,6 +93,9 @@ extension NotificationFilterOption {
         // REFUND_REVERSED - no subtype
         .init(.refundReversed),
 
+        // RESCIND_CONSENT - no subtype
+        .init(.rescindConsent),
+
         // RENEWAL_EXTENDED - no subtype, SUMMARY, FAILURE
         .init(.renewalExtended),
         .init(.renewalExtended, subtype: .summary),

--- a/Sources/IAPInterface/Model/NotificationHistoryItem+.swift
+++ b/Sources/IAPInterface/Model/NotificationHistoryItem+.swift
@@ -46,6 +46,8 @@ extension NotificationHistoryItem {
             return "creditcard.fill"
         case (.oneTimeCharge, _):
             return "cart.circle.fill"
+        case (.rescindConsent, _):
+            return "person.crop.circle.badge.xmark"
         case (.test, _):
             return "hammer"
         default:
@@ -74,6 +76,8 @@ extension NotificationHistoryItem {
             return .mint
         case (.externalPurchaseToken, .unreported):
             return .indigo
+        case (.rescindConsent, _):
+            return .orange
         case (.test, _):
             return .cyan
         default:

--- a/Sources/IAPInterface/Model/NotificationHistoryModel.swift
+++ b/Sources/IAPInterface/Model/NotificationHistoryModel.swift
@@ -50,6 +50,8 @@ public struct NotificationHistoryItem: Identifiable, Codable, Hashable, Sendable
     public let consumptionRequestReason: ConsumptionRequestReason?
     // MARK: - ExternalPurchaseToken
     public let externalPurchaseToken: ExternalPurchaseToken?
+    // MARK: - AppData
+    public let appData: AppData?
 
     public init?(
         _ payload: ResponseBodyV2DecodedPayload,
@@ -65,5 +67,6 @@ public struct NotificationHistoryItem: Identifiable, Codable, Hashable, Sendable
         self.renewalInfo = renewalInfo
         self.consumptionRequestReason = payload.data?.consumptionRequestReason
         self.externalPurchaseToken = payload.externalPurchaseToken
+        self.appData = payload.appData
     }
 }

--- a/Sources/IAPInterface/Model/NotificationTypeV2+.swift
+++ b/Sources/IAPInterface/Model/NotificationTypeV2+.swift
@@ -31,6 +31,7 @@ extension NotificationTypeV2: @retroactive CaseIterable {
             .refundReversed,
             .externalPurchaseToken,
             .oneTimeCharge,
+            .rescindConsent,
         ]
     }
 }

--- a/Sources/IAPView/AppStoreServerFieldFormatting.swift
+++ b/Sources/IAPView/AppStoreServerFieldFormatting.swift
@@ -1,0 +1,68 @@
+//
+//  AppStoreServerFieldFormatting.swift
+//
+//
+//  Created by Codex on 2026/05/09.
+//
+
+import IAPInterface
+
+extension JWSTransactionDecodedPayload {
+    var commitmentBillingPeriodNumberDescription: String? {
+        commitmentInfo?.billingPeriodNumber?.description
+    }
+
+    var commitmentTotalBillingPeriodsDescription: String? {
+        commitmentInfo?.totalBillingPeriods?.description
+    }
+
+    var commitmentExpiresDateDescription: String? {
+        commitmentInfo?.commitmentExpiresDate?.formatted()
+    }
+
+    var commitmentPriceDescription: String? {
+        commitmentInfo?.commitmentPrice?.description
+    }
+}
+
+extension JWSRenewalInfoDecodedPayload {
+    var commitmentAutoRenewStatusDescription: String? {
+        commitmentInfo?.commitmentAutoRenewStatus?.description
+    }
+
+    var commitmentRenewalDateDescription: String? {
+        commitmentInfo?.commitmentRenewalDate?.formatted()
+    }
+
+    var commitmentRenewalPriceDescription: String? {
+        commitmentInfo?.commitmentRenewalPrice?.description
+    }
+
+    var advancedCommercePriceIncreaseInfoDependentSKUDescription: String? {
+        let values =
+            advancedCommerceInfo?.items?
+            .compactMap { $0.priceIncreaseInfo?.dependentSKUs }
+            .flatMap { $0 } ?? []
+        return values.joinedIfNotEmpty
+    }
+
+    var advancedCommercePriceIncreaseInfoStatusDescription: String? {
+        let values =
+            advancedCommerceInfo?.items?
+            .compactMap { $0.priceIncreaseInfo?.status?.rawValue } ?? []
+        return values.joinedIfNotEmpty
+    }
+
+    var advancedCommercePriceIncreaseInfoPriceDescription: String? {
+        let values =
+            advancedCommerceInfo?.items?
+            .compactMap { $0.priceIncreaseInfo?.price?.description } ?? []
+        return values.joinedIfNotEmpty
+    }
+}
+
+extension Array where Element == String {
+    fileprivate var joinedIfNotEmpty: String? {
+        isEmpty ? nil : joined(separator: ", ")
+    }
+}

--- a/Sources/IAPView/NotificationColumnID.swift
+++ b/Sources/IAPView/NotificationColumnID.swift
@@ -28,7 +28,13 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
     case externalPurchaseId
     case tokenCreationDate
 
-    // Transaction columns (22)
+    // App Data columns (4)
+    case appDataAppAppleId
+    case appDataBundleId
+    case appDataEnvironment
+    case appDataSignedAppTransactionInfo
+
+    // Transaction columns (29)
     case notificationUUID
     case transactionReason
     case offerIdentifier
@@ -46,13 +52,20 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
     case storefrontId
     case webOrderLineItemId
     case revocationReason
+    case revocationType
+    case revocationPercentage
     case revocationDate
     case isUpgraded
     case transactionSignedDate
     case transactionAppTransactionId
     case transactionOfferPeriod
+    case billingPlanType
+    case commitmentBillingPeriodNumber
+    case commitmentTotalBillingPeriods
+    case commitmentExpiresDate
+    case commitmentPrice
 
-    // Renewal Info columns (21)
+    // Renewal Info columns (30)
     case expirationIntent
     case renewalOriginalTransactionId
     case autoRenewProductId
@@ -74,6 +87,15 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
     case renewalAppTransactionId
     case renewalOfferPeriod
     case renewalAppAccountToken
+    case renewalBillingPlanType
+    case renewalCommitmentAutoRenewProductId
+    case renewalCommitmentAutoRenewStatus
+    case renewalCommitmentRenewalBillingPlanType
+    case renewalCommitmentRenewalDate
+    case renewalCommitmentRenewalPrice
+    case advancedCommercePriceIncreaseInfoDependentSKU
+    case advancedCommercePriceIncreaseInfoStatus
+    case advancedCommercePriceIncreaseInfoPrice
 
     var id: String { rawValue }
 
@@ -95,6 +117,11 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
         case .consumptionRequestReason: "consumptionRequestReason"
         case .externalPurchaseId: "externalPurchaseId"
         case .tokenCreationDate: "tokenCreationDate"
+        // App Data
+        case .appDataAppAppleId: "appAppleId"
+        case .appDataBundleId: "bundleId"
+        case .appDataEnvironment: "environment"
+        case .appDataSignedAppTransactionInfo: "signedAppTransactionInfo"
         // Transaction
         case .notificationUUID: "notificationUUID"
         case .transactionReason: "transactionReason"
@@ -113,11 +140,18 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
         case .storefrontId: "storefrontId"
         case .webOrderLineItemId: "webOrderLineItemId"
         case .revocationReason: "revocationReason"
+        case .revocationType: "revocationType"
+        case .revocationPercentage: "revocationPercentage"
         case .revocationDate: "revocationDate"
         case .isUpgraded: "isUpgraded"
         case .transactionSignedDate: "signedDate"
         case .transactionAppTransactionId: "appTransactionId"
         case .transactionOfferPeriod: "offerPeriod"
+        case .billingPlanType: "billingPlanType"
+        case .commitmentBillingPeriodNumber: "billingPeriodNumber"
+        case .commitmentTotalBillingPeriods: "totalBillingPeriods"
+        case .commitmentExpiresDate: "commitmentExpiresDate"
+        case .commitmentPrice: "commitmentPrice"
         // Renewal Info
         case .expirationIntent: "expirationIntent"
         case .renewalOriginalTransactionId: "originalTransactionId"
@@ -140,6 +174,16 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
         case .renewalAppTransactionId: "appTransactionId"
         case .renewalOfferPeriod: "offerPeriod"
         case .renewalAppAccountToken: "appAccountToken"
+        case .renewalBillingPlanType: "renewalBillingPlanType"
+        case .renewalCommitmentAutoRenewProductId: "commitmentAutoRenewProductId"
+        case .renewalCommitmentAutoRenewStatus: "commitmentAutoRenewStatus"
+        case .renewalCommitmentRenewalBillingPlanType: "commitmentRenewalBillingPlanType"
+        case .renewalCommitmentRenewalDate: "commitmentRenewalDate"
+        case .renewalCommitmentRenewalPrice: "commitmentRenewalPrice"
+        case .advancedCommercePriceIncreaseInfoDependentSKU:
+            "advancedCommercePriceIncreaseInfoDependentSKU"
+        case .advancedCommercePriceIncreaseInfoStatus: "advancedCommercePriceIncreaseInfoStatus"
+        case .advancedCommercePriceIncreaseInfoPrice: "advancedCommercePriceIncreaseInfoPrice"
         }
     }
 
@@ -149,6 +193,14 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
         case .transactionSignedDate: "transaction signedDate"
         case .transactionAppTransactionId: "transaction appTransactionId"
         case .transactionOfferPeriod: "transaction offerPeriod"
+        case .appDataAppAppleId: "appData.appAppleId"
+        case .appDataBundleId: "appData.bundleId"
+        case .appDataEnvironment: "appData.environment"
+        case .appDataSignedAppTransactionInfo: "appData.signedAppTransactionInfo"
+        case .commitmentBillingPeriodNumber: "commitmentInfo.billingPeriodNumber"
+        case .commitmentTotalBillingPeriods: "commitmentInfo.totalBillingPeriods"
+        case .commitmentExpiresDate: "commitmentInfo.commitmentExpiresDate"
+        case .commitmentPrice: "commitmentInfo.commitmentPrice"
         case .renewalOriginalTransactionId: "renewal originalTransactionId"
         case .renewalProductId: "renewal productId"
         case .renewalOfferType: "renewal offerType"
@@ -160,29 +212,57 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
         case .renewalAppTransactionId: "renewal appTransactionId"
         case .renewalOfferPeriod: "renewal offerPeriod"
         case .renewalAppAccountToken: "renewal appAccountToken"
+        case .renewalCommitmentAutoRenewProductId:
+            "renewal commitmentInfo.commitmentAutoRenewProductId"
+        case .renewalCommitmentAutoRenewStatus:
+            "renewal commitmentInfo.commitmentAutoRenewStatus"
+        case .renewalCommitmentRenewalBillingPlanType:
+            "renewal commitmentInfo.commitmentRenewalBillingPlanType"
+        case .renewalCommitmentRenewalDate:
+            "renewal commitmentInfo.commitmentRenewalDate"
+        case .renewalCommitmentRenewalPrice:
+            "renewal commitmentInfo.commitmentRenewalPrice"
+        case .advancedCommercePriceIncreaseInfoDependentSKU:
+            "advancedCommercePriceIncreaseInfo.dependentSKU"
+        case .advancedCommercePriceIncreaseInfoStatus:
+            "advancedCommercePriceIncreaseInfo.status"
+        case .advancedCommercePriceIncreaseInfoPrice:
+            "advancedCommercePriceIncreaseInfo.price"
         default: displayName
         }
     }
 
     /// URL to Apple's API documentation for this field
     var documentationURL: URL {
-        let baseURL = "https://developer.apple.com/documentation/appstoreserverapi/"
+        let baseURL =
+            switch self {
+            case .appDataAppAppleId, .appDataBundleId, .appDataEnvironment,
+                .appDataSignedAppTransactionInfo:
+                "https://developer.apple.com/documentation/appstoreservernotifications/"
+            default:
+                "https://developer.apple.com/documentation/appstoreserverapi/"
+            }
         return URL(string: baseURL + displayName.lowercased())!
     }
 
     /// Column width category
     var width: ColumnWidth {
         switch self {
-        case .price, .currency, .quantity, .storefront, .renewalCurrency:
+        case .price, .currency, .quantity, .storefront, .renewalCurrency,
+            .commitmentBillingPeriodNumber, .commitmentTotalBillingPeriods,
+            .revocationPercentage:
             .small
-        case .environment, .storefrontId, .renewalEnvironment:
+        case .environment, .storefrontId, .renewalEnvironment, .appDataEnvironment,
+            .billingPlanType, .revocationType, .renewalBillingPlanType,
+            .renewalCommitmentAutoRenewStatus, .renewalCommitmentRenewalBillingPlanType:
             .medium
         case .notificationType, .subscriptionGroupIdentifier, .type, .inAppOwnershipType,
-            .recentSubscriptionStartDate, .consumptionRequestReason, .subType:
+            .recentSubscriptionStartDate, .consumptionRequestReason, .subType,
+            .appDataSignedAppTransactionInfo, .advancedCommercePriceIncreaseInfoDependentSKU:
             .extraLarge
         case .originalTransactionID, .transactionID, .bundleId, .productId,
             .webOrderLineItemId, .renewalOriginalTransactionId, .renewalProductId,
-            .notificationUUID:
+            .notificationUUID, .appDataBundleId, .renewalCommitmentAutoRenewProductId:
             .large
         default:
             .medium
@@ -198,12 +278,17 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
             .main
         case .consumptionRequestReason, .externalPurchaseId, .tokenCreationDate:
             .external
+        case .appDataAppAppleId, .appDataBundleId, .appDataEnvironment,
+            .appDataSignedAppTransactionInfo:
+            .appData
         case .notificationUUID, .transactionReason, .offerIdentifier, .offerType,
             .offerDiscountType, .appAccountToken, .bundleId, .productId,
             .subscriptionGroupIdentifier, .quantity, .type, .inAppOwnershipType,
             .environment, .storefront, .storefrontId, .webOrderLineItemId,
-            .revocationReason, .revocationDate, .isUpgraded, .transactionSignedDate,
-            .transactionAppTransactionId, .transactionOfferPeriod:
+            .revocationReason, .revocationType, .revocationPercentage, .revocationDate,
+            .isUpgraded, .transactionSignedDate, .transactionAppTransactionId,
+            .transactionOfferPeriod, .billingPlanType, .commitmentBillingPeriodNumber,
+            .commitmentTotalBillingPeriods, .commitmentExpiresDate, .commitmentPrice:
             .transaction
         case .expirationIntent, .renewalOriginalTransactionId, .autoRenewProductId,
             .renewalProductId, .autoRenewStatus, .isInBillingRetryPeriod,
@@ -211,7 +296,12 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
             .renewalOfferIdentifier, .renewalSignedDate, .renewalEnvironment,
             .recentSubscriptionStartDate, .renewalDate, .renewalPrice,
             .renewalCurrency, .renewalOfferDiscountType, .eligibleWinBackOfferIds,
-            .renewalAppTransactionId, .renewalOfferPeriod, .renewalAppAccountToken:
+            .renewalAppTransactionId, .renewalOfferPeriod, .renewalAppAccountToken,
+            .renewalBillingPlanType, .renewalCommitmentAutoRenewProductId,
+            .renewalCommitmentAutoRenewStatus, .renewalCommitmentRenewalBillingPlanType,
+            .renewalCommitmentRenewalDate, .renewalCommitmentRenewalPrice,
+            .advancedCommercePriceIncreaseInfoDependentSKU,
+            .advancedCommercePriceIncreaseInfoStatus, .advancedCommercePriceIncreaseInfoPrice:
             .renewalInfo
         }
     }
@@ -219,6 +309,7 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
     enum ColumnCategory: String, CaseIterable {
         case main = "Main"
         case external = "External"
+        case appData = "App Data"
         case transaction = "Transaction"
         case renewalInfo = "Renewal Info"
     }
@@ -272,6 +363,15 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
             item.externalPurchaseToken?.tokenCreationDate.map {
                 Date(timeIntervalSince1970: TimeInterval($0))
             }?.formatted()
+        // App Data
+        case .appDataAppAppleId:
+            item.appData?.appAppleId?.description
+        case .appDataBundleId:
+            item.appData?.bundleId
+        case .appDataEnvironment:
+            item.appData?.environment?.rawValue
+        case .appDataSignedAppTransactionInfo:
+            item.appData?.signedAppTransactionInfo
         // Transaction
         case .notificationUUID:
             item.id.rawValue
@@ -307,6 +407,10 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
             item.transactionInfo?.webOrderLineItemId
         case .revocationReason:
             item.transactionInfo?.revocationReason?.description
+        case .revocationType:
+            item.transactionInfo?.revocationType?.rawValue
+        case .revocationPercentage:
+            item.transactionInfo?.revocationPercentage?.description
         case .revocationDate:
             item.transactionInfo?.revocationDate?.formatted()
         case .isUpgraded:
@@ -317,6 +421,16 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
             item.transactionInfo?.appTransactionId
         case .transactionOfferPeriod:
             item.transactionInfo?.offerPeriod
+        case .billingPlanType:
+            item.transactionInfo?.billingPlanType?.rawValue
+        case .commitmentBillingPeriodNumber:
+            item.transactionInfo?.commitmentBillingPeriodNumberDescription
+        case .commitmentTotalBillingPeriods:
+            item.transactionInfo?.commitmentTotalBillingPeriodsDescription
+        case .commitmentExpiresDate:
+            item.transactionInfo?.commitmentExpiresDateDescription
+        case .commitmentPrice:
+            item.transactionInfo?.commitmentPriceDescription
         // Renewal Info
         case .expirationIntent:
             item.renewalInfo?.expirationIntent?.description
@@ -360,6 +474,24 @@ enum NotificationColumnID: String, CaseIterable, Identifiable, Codable {
             item.renewalInfo?.offerPeriod
         case .renewalAppAccountToken:
             item.renewalInfo?.appAccountToken?.uuidString
+        case .renewalBillingPlanType:
+            item.renewalInfo?.renewalBillingPlanType?.rawValue
+        case .renewalCommitmentAutoRenewProductId:
+            item.renewalInfo?.commitmentInfo?.commitmentAutoRenewProductId
+        case .renewalCommitmentAutoRenewStatus:
+            item.renewalInfo?.commitmentAutoRenewStatusDescription
+        case .renewalCommitmentRenewalBillingPlanType:
+            item.renewalInfo?.commitmentInfo?.commitmentRenewalBillingPlanType?.rawValue
+        case .renewalCommitmentRenewalDate:
+            item.renewalInfo?.commitmentRenewalDateDescription
+        case .renewalCommitmentRenewalPrice:
+            item.renewalInfo?.commitmentRenewalPriceDescription
+        case .advancedCommercePriceIncreaseInfoDependentSKU:
+            item.renewalInfo?.advancedCommercePriceIncreaseInfoDependentSKUDescription
+        case .advancedCommercePriceIncreaseInfoStatus:
+            item.renewalInfo?.advancedCommercePriceIncreaseInfoStatusDescription
+        case .advancedCommercePriceIncreaseInfoPrice:
+            item.renewalInfo?.advancedCommercePriceIncreaseInfoPriceDescription
         }
     }
 }

--- a/Sources/IAPView/SubscriptionColumnID.swift
+++ b/Sources/IAPView/SubscriptionColumnID.swift
@@ -38,13 +38,20 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
     case storefrontId
     case webOrderLineItemId
     case revocationReason
+    case revocationType
+    case revocationPercentage
     case revocationDate
     case isUpgraded
     case transactionSignedDate
     case appTransactionId
     case offerPeriod
+    case billingPlanType
+    case commitmentBillingPeriodNumber
+    case commitmentTotalBillingPeriods
+    case commitmentExpiresDate
+    case commitmentPrice
 
-    // Renewal Info columns (21)
+    // Renewal Info columns (30)
     case expirationIntent
     case renewalOriginalTransactionId
     case autoRenewProductId
@@ -66,6 +73,15 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
     case renewalAppTransactionId
     case renewalOfferPeriod
     case renewalAppAccountToken
+    case renewalBillingPlanType
+    case renewalCommitmentAutoRenewProductId
+    case renewalCommitmentAutoRenewStatus
+    case renewalCommitmentRenewalBillingPlanType
+    case renewalCommitmentRenewalDate
+    case renewalCommitmentRenewalPrice
+    case advancedCommercePriceIncreaseInfoDependentSKU
+    case advancedCommercePriceIncreaseInfoStatus
+    case advancedCommercePriceIncreaseInfoPrice
 
     var id: String { rawValue }
 
@@ -98,11 +114,18 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
         case .storefrontId: "storefrontId"
         case .webOrderLineItemId: "webOrderLineItemId"
         case .revocationReason: "revocationReason"
+        case .revocationType: "revocationType"
+        case .revocationPercentage: "revocationPercentage"
         case .revocationDate: "revocationDate"
         case .isUpgraded: "isUpgraded"
         case .transactionSignedDate: "signedDate"
         case .appTransactionId: "appTransactionId"
         case .offerPeriod: "offerPeriod"
+        case .billingPlanType: "billingPlanType"
+        case .commitmentBillingPeriodNumber: "billingPeriodNumber"
+        case .commitmentTotalBillingPeriods: "totalBillingPeriods"
+        case .commitmentExpiresDate: "commitmentExpiresDate"
+        case .commitmentPrice: "commitmentPrice"
         // Renewal Info
         case .expirationIntent: "expirationIntent"
         case .renewalOriginalTransactionId: "originalTransactionId"
@@ -125,6 +148,16 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
         case .renewalAppTransactionId: "appTransactionId"
         case .renewalOfferPeriod: "offerPeriod"
         case .renewalAppAccountToken: "appAccountToken"
+        case .renewalBillingPlanType: "renewalBillingPlanType"
+        case .renewalCommitmentAutoRenewProductId: "commitmentAutoRenewProductId"
+        case .renewalCommitmentAutoRenewStatus: "commitmentAutoRenewStatus"
+        case .renewalCommitmentRenewalBillingPlanType: "commitmentRenewalBillingPlanType"
+        case .renewalCommitmentRenewalDate: "commitmentRenewalDate"
+        case .renewalCommitmentRenewalPrice: "commitmentRenewalPrice"
+        case .advancedCommercePriceIncreaseInfoDependentSKU:
+            "advancedCommercePriceIncreaseInfoDependentSKU"
+        case .advancedCommercePriceIncreaseInfoStatus: "advancedCommercePriceIncreaseInfoStatus"
+        case .advancedCommercePriceIncreaseInfoPrice: "advancedCommercePriceIncreaseInfoPrice"
         }
     }
 
@@ -132,6 +165,10 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
     var columnHeader: String {
         switch self {
         case .transactionSignedDate: "transaction signedDate"
+        case .commitmentBillingPeriodNumber: "commitmentInfo.billingPeriodNumber"
+        case .commitmentTotalBillingPeriods: "commitmentInfo.totalBillingPeriods"
+        case .commitmentExpiresDate: "commitmentInfo.commitmentExpiresDate"
+        case .commitmentPrice: "commitmentInfo.commitmentPrice"
         case .renewalOriginalTransactionId: "renewal originalTransactionId"
         case .renewalProductId: "renewal productId"
         case .renewalOfferType: "renewal offerType"
@@ -143,6 +180,22 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
         case .renewalAppTransactionId: "renewal appTransactionId"
         case .renewalOfferPeriod: "renewal offerPeriod"
         case .renewalAppAccountToken: "renewal appAccountToken"
+        case .renewalCommitmentAutoRenewProductId:
+            "renewal commitmentInfo.commitmentAutoRenewProductId"
+        case .renewalCommitmentAutoRenewStatus:
+            "renewal commitmentInfo.commitmentAutoRenewStatus"
+        case .renewalCommitmentRenewalBillingPlanType:
+            "renewal commitmentInfo.commitmentRenewalBillingPlanType"
+        case .renewalCommitmentRenewalDate:
+            "renewal commitmentInfo.commitmentRenewalDate"
+        case .renewalCommitmentRenewalPrice:
+            "renewal commitmentInfo.commitmentRenewalPrice"
+        case .advancedCommercePriceIncreaseInfoDependentSKU:
+            "advancedCommercePriceIncreaseInfo.dependentSKU"
+        case .advancedCommercePriceIncreaseInfoStatus:
+            "advancedCommercePriceIncreaseInfo.status"
+        case .advancedCommercePriceIncreaseInfoPrice:
+            "advancedCommercePriceIncreaseInfo.price"
         default: displayName
         }
     }
@@ -156,15 +209,20 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
     /// Column width category
     var width: ColumnWidth {
         switch self {
-        case .price, .currency, .quantity, .storefront, .renewalCurrency:
+        case .price, .currency, .quantity, .storefront, .renewalCurrency,
+            .commitmentBillingPeriodNumber, .commitmentTotalBillingPeriods,
+            .revocationPercentage:
             .small
-        case .environment, .storefrontId, .renewalEnvironment:
+        case .environment, .storefrontId, .renewalEnvironment, .billingPlanType,
+            .revocationType, .renewalBillingPlanType, .renewalCommitmentAutoRenewStatus,
+            .renewalCommitmentRenewalBillingPlanType:
             .medium
         case .subscriptionGroupIdentifier, .status, .type, .inAppOwnershipType,
-            .recentSubscriptionStartDate:
+            .recentSubscriptionStartDate, .advancedCommercePriceIncreaseInfoDependentSKU:
             .extraLarge
         case .originalTransactionID, .transactionID, .bundleId, .productId,
-            .webOrderLineItemId, .renewalOriginalTransactionId, .renewalProductId:
+            .webOrderLineItemId, .renewalOriginalTransactionId, .renewalProductId,
+            .renewalCommitmentAutoRenewProductId:
             .large
         default:
             .medium
@@ -181,8 +239,10 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
         case .transactionReason, .offerIdentifier, .offerType, .offerDiscountType,
             .appAccountToken, .bundleId, .productId, .quantity, .type,
             .inAppOwnershipType, .environment, .storefront, .storefrontId,
-            .webOrderLineItemId, .revocationReason, .revocationDate, .isUpgraded,
-            .transactionSignedDate, .appTransactionId, .offerPeriod:
+            .webOrderLineItemId, .revocationReason, .revocationType,
+            .revocationPercentage, .revocationDate, .isUpgraded, .transactionSignedDate,
+            .appTransactionId, .offerPeriod, .billingPlanType, .commitmentBillingPeriodNumber,
+            .commitmentTotalBillingPeriods, .commitmentExpiresDate, .commitmentPrice:
             .transaction
         case .expirationIntent, .renewalOriginalTransactionId, .autoRenewProductId,
             .renewalProductId, .autoRenewStatus, .isInBillingRetryPeriod,
@@ -190,7 +250,12 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
             .renewalOfferIdentifier, .renewalSignedDate, .renewalEnvironment,
             .recentSubscriptionStartDate, .renewalDate, .renewalPrice,
             .renewalCurrency, .renewalOfferDiscountType, .eligibleWinBackOfferIds,
-            .renewalAppTransactionId, .renewalOfferPeriod, .renewalAppAccountToken:
+            .renewalAppTransactionId, .renewalOfferPeriod, .renewalAppAccountToken,
+            .renewalBillingPlanType, .renewalCommitmentAutoRenewProductId,
+            .renewalCommitmentAutoRenewStatus, .renewalCommitmentRenewalBillingPlanType,
+            .renewalCommitmentRenewalDate, .renewalCommitmentRenewalPrice,
+            .advancedCommercePriceIncreaseInfoDependentSKU,
+            .advancedCommercePriceIncreaseInfoStatus, .advancedCommercePriceIncreaseInfoPrice:
             .renewalInfo
         }
     }
@@ -271,6 +336,10 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
             item.transaction?.webOrderLineItemId
         case .revocationReason:
             item.transaction?.revocationReason?.description
+        case .revocationType:
+            item.transaction?.revocationType?.rawValue
+        case .revocationPercentage:
+            item.transaction?.revocationPercentage?.description
         case .revocationDate:
             item.transaction?.revocationDate?.formatted()
         case .isUpgraded:
@@ -281,6 +350,16 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
             item.transaction?.appTransactionId
         case .offerPeriod:
             item.transaction?.offerPeriod
+        case .billingPlanType:
+            item.transaction?.billingPlanType?.rawValue
+        case .commitmentBillingPeriodNumber:
+            item.transaction?.commitmentBillingPeriodNumberDescription
+        case .commitmentTotalBillingPeriods:
+            item.transaction?.commitmentTotalBillingPeriodsDescription
+        case .commitmentExpiresDate:
+            item.transaction?.commitmentExpiresDateDescription
+        case .commitmentPrice:
+            item.transaction?.commitmentPriceDescription
         // Renewal Info
         case .expirationIntent:
             item.renewalInfo?.expirationIntent?.description
@@ -324,6 +403,24 @@ enum SubscriptionColumnID: String, CaseIterable, Identifiable, Codable {
             item.renewalInfo?.offerPeriod
         case .renewalAppAccountToken:
             item.renewalInfo?.appAccountToken?.uuidString
+        case .renewalBillingPlanType:
+            item.renewalInfo?.renewalBillingPlanType?.rawValue
+        case .renewalCommitmentAutoRenewProductId:
+            item.renewalInfo?.commitmentInfo?.commitmentAutoRenewProductId
+        case .renewalCommitmentAutoRenewStatus:
+            item.renewalInfo?.commitmentAutoRenewStatusDescription
+        case .renewalCommitmentRenewalBillingPlanType:
+            item.renewalInfo?.commitmentInfo?.commitmentRenewalBillingPlanType?.rawValue
+        case .renewalCommitmentRenewalDate:
+            item.renewalInfo?.commitmentRenewalDateDescription
+        case .renewalCommitmentRenewalPrice:
+            item.renewalInfo?.commitmentRenewalPriceDescription
+        case .advancedCommercePriceIncreaseInfoDependentSKU:
+            item.renewalInfo?.advancedCommercePriceIncreaseInfoDependentSKUDescription
+        case .advancedCommercePriceIncreaseInfoStatus:
+            item.renewalInfo?.advancedCommercePriceIncreaseInfoStatusDescription
+        case .advancedCommercePriceIncreaseInfoPrice:
+            item.renewalInfo?.advancedCommercePriceIncreaseInfoPriceDescription
         }
     }
 }

--- a/Sources/IAPView/TransactionColumnID.swift
+++ b/Sources/IAPView/TransactionColumnID.swift
@@ -32,6 +32,11 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
     case offerType
     case offerDiscountType
     case offerPeriod
+    case billingPlanType
+    case commitmentBillingPeriodNumber
+    case commitmentTotalBillingPeriods
+    case commitmentExpiresDate
+    case commitmentPrice
     case appAccountToken
     case bundleId
     case productId
@@ -44,6 +49,8 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
     case storefrontId
     case webOrderLineItemId
     case revocationReason
+    case revocationType
+    case revocationPercentage
     case revocationDate
     case isUpgraded
     case signedDate
@@ -66,6 +73,11 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
         case .offerType: "offerType"
         case .offerDiscountType: "offerDiscountType"
         case .offerPeriod: "offerPeriod"
+        case .billingPlanType: "billingPlanType"
+        case .commitmentBillingPeriodNumber: "billingPeriodNumber"
+        case .commitmentTotalBillingPeriods: "totalBillingPeriods"
+        case .commitmentExpiresDate: "commitmentExpiresDate"
+        case .commitmentPrice: "commitmentPrice"
         case .appAccountToken: "appAccountToken"
         case .bundleId: "bundleId"
         case .productId: "productId"
@@ -78,9 +90,22 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
         case .storefrontId: "storefrontId"
         case .webOrderLineItemId: "webOrderLineItemId"
         case .revocationReason: "revocationReason"
+        case .revocationType: "revocationType"
+        case .revocationPercentage: "revocationPercentage"
         case .revocationDate: "revocationDate"
         case .isUpgraded: "isUpgraded"
         case .signedDate: "signedDate"
+        }
+    }
+
+    /// Column header text (with prefix for nested commitment info fields)
+    var columnHeader: String {
+        switch self {
+        case .commitmentBillingPeriodNumber: "commitmentInfo.billingPeriodNumber"
+        case .commitmentTotalBillingPeriods: "commitmentInfo.totalBillingPeriods"
+        case .commitmentExpiresDate: "commitmentInfo.commitmentExpiresDate"
+        case .commitmentPrice: "commitmentInfo.commitmentPrice"
+        default: displayName
         }
     }
 
@@ -93,13 +118,15 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
     /// Column width category
     var width: ColumnWidth {
         switch self {
-        case .price, .currency, .quantity, .storefront:
+        case .price, .currency, .quantity, .storefront, .commitmentBillingPeriodNumber,
+            .commitmentTotalBillingPeriods, .revocationPercentage:
             .small
-        case .environment, .storefrontId:
+        case .environment, .storefrontId, .billingPlanType, .revocationType:
             .medium
         case .purchaseDate, .originalPurchaseDate, .expiresDate, .revocationDate, .signedDate,
             .offerIdentifier, .offerType, .offerDiscountType, .offerPeriod,
-            .appAccountToken, .revocationReason, .isUpgraded, .appTransactionId:
+            .appAccountToken, .revocationReason, .isUpgraded, .appTransactionId,
+            .commitmentExpiresDate, .commitmentPrice:
             .medium
         case .originalTransactionID, .transactionID, .bundleId, .productId, .webOrderLineItemId:
             .large
@@ -154,6 +181,16 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
             payload.offerDiscountType?.rawValue
         case .offerPeriod:
             payload.offerPeriod
+        case .billingPlanType:
+            payload.billingPlanType?.rawValue
+        case .commitmentBillingPeriodNumber:
+            payload.commitmentBillingPeriodNumberDescription
+        case .commitmentTotalBillingPeriods:
+            payload.commitmentTotalBillingPeriodsDescription
+        case .commitmentExpiresDate:
+            payload.commitmentExpiresDateDescription
+        case .commitmentPrice:
+            payload.commitmentPriceDescription
         case .appAccountToken:
             payload.appAccountToken?.uuidString
         case .bundleId:
@@ -178,6 +215,10 @@ enum TransactionColumnID: String, CaseIterable, Identifiable, Codable {
             payload.webOrderLineItemId
         case .revocationReason:
             payload.revocationReason?.description
+        case .revocationType:
+            payload.revocationType?.rawValue
+        case .revocationPercentage:
+            payload.revocationPercentage?.description
         case .revocationDate:
             payload.revocationDate?.formatted()
         case .isUpgraded:

--- a/Sources/IAPView/TransactionColumnInspectorView.swift
+++ b/Sources/IAPView/TransactionColumnInspectorView.swift
@@ -102,7 +102,7 @@ private struct ColumnToggleRow: View {
 
     @ViewBuilder
     private var linkLabel: some View {
-        let link = Link(columnID.displayName, destination: columnID.documentationURL)
+        let link = Link(columnID.columnHeader, destination: columnID.documentationURL)
             .foregroundStyle(isVisible ? Color.accentColor : Color.secondary)
             .underline(isVisible)
             .help(columnID.documentationURL.absoluteString)

--- a/Sources/IAPView/TransactionHistoryTableView.swift
+++ b/Sources/IAPView/TransactionHistoryTableView.swift
@@ -42,7 +42,7 @@ struct TransactionHistoryTableView: View {
 
         Table(of: JWSTransactionDecodedPayload.self, columnCustomization: $columnCustomization) {
             TableColumnForEach(columnOrder.columns) { columnID in
-                TableColumn(columnID.displayName) { payload in
+                TableColumn(columnID.columnHeader) { payload in
                     cellContent(for: columnID, payload: payload)
                 }
                 .width(min: columnID.width.rawValue, ideal: columnID.width.rawValue)

--- a/Sources/IAPView/TransactionInfoTableView.swift
+++ b/Sources/IAPView/TransactionInfoTableView.swift
@@ -41,7 +41,7 @@ struct TransactionInfoTableView: View {
 
         Table(of: JWSTransactionDecodedPayload.self, columnCustomization: $columnCustomization) {
             TableColumnForEach(columnOrder.columns) { columnID in
-                TableColumn(columnID.displayName) { payload in
+                TableColumn(columnID.columnHeader) { payload in
                     cellContent(for: columnID, payload: payload)
                 }
                 .width(min: columnID.width.rawValue, ideal: columnID.width.rawValue)

--- a/Tests/IAPInterfaceTests/CaseIterableTests.swift
+++ b/Tests/IAPInterfaceTests/CaseIterableTests.swift
@@ -43,12 +43,13 @@ struct CaseIterableTests {
     /// UPDATE THIS TEST when AppStoreServerLibrary adds new NotificationTypeV2 cases.
     @Test
     func notificationTypeV2ExpectedCount() {
-        // As of app-store-server-library-swift 4.0.0 (API v1.18)
+        // As of app-store-server-library-swift 6.0.0
         // Expected cases: subscribed, didChangeRenewalPref, didChangeRenewalStatus,
         // offerRedeemed, didRenew, expired, didFailToRenew, gracePeriodExpired,
         // priceIncrease, refund, refundDeclined, consumptionRequest, renewalExtended,
-        // revoke, test, renewalExtension, refundReversed, externalPurchaseToken, oneTimeCharge
-        let expectedCount = 19
+        // revoke, test, renewalExtension, refundReversed, externalPurchaseToken, oneTimeCharge,
+        // rescindConsent
+        let expectedCount = 20
         #expect(
             NotificationTypeV2.allCases.count == expectedCount,
             """
@@ -127,7 +128,7 @@ struct CaseIterableTests {
     func notificationFilterOptionExpectedCount() {
         // Based on https://developer.apple.com/documentation/appstoreservernotifications/notificationtype
         // Only includes explicitly documented combinations
-        let expectedCount = 36
+        let expectedCount = 37
         #expect(
             NotificationFilterOption.allOptions.count == expectedCount,
             """


### PR DESCRIPTION
## Summary
- Add table and inspector display support for recently added App Store Server transaction, renewal, revocation, commitment, Advanced Commerce price increase, and appData fields.
- Add RESCIND_CONSENT to notification type handling, filtering, icons, and CaseIterable coverage.
- Preserve the existing column customization pattern so new fields appear in the existing transaction, subscription, and notification views.

## Validation
- swift test
- xcodebuild Development scheme / Debug / macOS
- git diff --check