### PR TITLE
Prioritize reload requests in loading state management

### DIFF
--- a/Sources/IAPInterface/AppStoreServerClientInterface.swift
+++ b/Sources/IAPInterface/AppStoreServerClientInterface.swift
@@ -28,8 +28,7 @@ public struct AppStoreServerClient: Sendable {
     }
 
     public var fetchNotificationHistory:
-        @Sendable
-        (
+        @Sendable (
             _ request: NotificationHistoryRequest,
             _ paginationToken: String?,
             _ credential: IAPEnvironment, _ rootCertificate: Data, _ environment: ServerEnvironment
@@ -37,23 +36,20 @@ public struct AppStoreServerClient: Sendable {
             async throws -> NotificationHistoryModel
 
     public var fetchTransactionHistory:
-        @Sendable
-        (
+        @Sendable (
             _ startDate: Date, _ endDate: Date, _ transactionID: String,
             _ revision: String?, _ credential: IAPEnvironment, _ rootCertificate: Data,
             _ environment: ServerEnvironment
         ) async throws -> TransactionHistory
 
     public var fetchAllSubscriptionStatuses:
-        @Sendable
-        (
+        @Sendable (
             _ transactionID: String, _ credential: IAPEnvironment, _ rootCertificate: Data,
             _ environment: ServerEnvironment
         ) async throws -> SubscriptionStatus
 
     public var fetchTransactionInfo:
-        @Sendable
-        (
+        @Sendable (
             _ transactionID: String, _ credential: IAPEnvironment, _ rootCertificate: Data,
             _ environment: ServerEnvironment
         ) async throws -> JWSTransactionDecodedPayload

--- a/Sources/IAPInterface/CredentialClientInterface.swift
+++ b/Sources/IAPInterface/CredentialClientInterface.swift
@@ -22,8 +22,7 @@ public struct CredentialClient: Sendable {
 
     public var get: @Sendable () async throws -> Model?
     public var set:
-        @Sendable
-        (
+        @Sendable (
             _ bundleID: String, _ issuerID: String, _ keyID: String, _ appAppleID: Int,
             _ privateKeyFileURL: URL
         )

--- a/Sources/IAPModel/IAPModel.swift
+++ b/Sources/IAPModel/IAPModel.swift
@@ -18,6 +18,30 @@ public final class IAPModel {
     @ObservationIgnored
     @Dependency(\.calendar) var calendar
 
+    @ObservationIgnored
+    private var fetchNotificationHistoryTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var fetchNotificationHistoryGeneration = 0
+
+    @ObservationIgnored
+    private var fetchTransactionHistoryTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var fetchTransactionHistoryGeneration = 0
+
+    @ObservationIgnored
+    private var fetchAllSubscriptionStatusesTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var fetchAllSubscriptionStatusesGeneration = 0
+
+    @ObservationIgnored
+    private var fetchTransactionInfoTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var fetchTransactionInfoGeneration = 0
+
     // MARK: - State model
 
     public private(set) var rootCertificateState: LoadingViewState<Data> = .waiting
@@ -106,21 +130,25 @@ extension IAPModel {
         case removeAll
 
         case fetchNotificationHistory(startDate: Date, endDate: Date, transactionID: String)
+        case reloadNotificationHistory(startDate: Date, endDate: Date, transactionID: String)
         case appendFetchNotificationHistory(startDate: Date, endDate: Date, transactionID: String)
         case bulkAppendFetchNotificationHistory(
             startDate: Date, endDate: Date, transactionID: String)
         case clearNotificationHistoryError
 
         case fetchTransactionHistory(startDate: Date, endDate: Date, transactionID: String)
+        case reloadTransactionHistory(startDate: Date, endDate: Date, transactionID: String)
         case appendFetchTransactionHistory(startDate: Date, endDate: Date, transactionID: String)
         case bulkAppendFetchTransactionHistory(
             startDate: Date, endDate: Date, transactionID: String)
         case clearTransactionHistoryError
 
         case fetchAllSubscriptionStatuses(transactionID: String)
+        case reloadAllSubscriptionStatuses(transactionID: String)
         case clearAllSubscriptionStatusesError
 
         case fetchTransactionInfo(transactionID: String)
+        case reloadTransactionInfo(transactionID: String)
         case clearTransactionInfoError
     }
 
@@ -135,7 +163,7 @@ extension IAPModel {
 
         switch action {
         case .getRootCertificate:
-            guard !rootCertificateState.isLoading else { return }
+            guard !rootCertificateState.isLoadingOrAppending else { return }
             rootCertificateState.startLoading()
             do {
                 if let data = try await rootCertificateClient.get() {
@@ -148,7 +176,7 @@ extension IAPModel {
                     with: IAPError.unknownError(message: error.localizedDescription))
             }
         case .fetchRootCertificate:
-            guard !rootCertificateState.isLoading else { return }
+            guard !rootCertificateState.isLoadingOrAppending else { return }
             rootCertificateState.startLoading()
             do {
                 let data = try await rootCertificateClient.fetch()
@@ -160,7 +188,7 @@ extension IAPModel {
             }
 
         case .getCredential:
-            guard !credentialState.isLoading else { return }
+            guard !credentialState.isLoadingOrAppending else { return }
             credentialState.startLoading()
             do {
                 try await Task.sleep(for: .seconds(0.2))  // avoid blink for UX
@@ -176,7 +204,7 @@ extension IAPModel {
 
         case .saveCredential(
             let bundleID, let issuerID, let keyID, let appAppleID, let privateKeyFileURL):
-            guard !credentialState.isLoading else { return }
+            guard !credentialState.isLoadingOrAppending else { return }
             credentialState.startLoading()
             do {
                 try await credentialClient.set(
@@ -192,7 +220,7 @@ extension IAPModel {
                     with: .unknownError(message: error.localizedDescription))
             }
         case .removeAll:
-            guard !removeState.isLoading else { return }
+            guard !removeState.isLoadingOrAppending else { return }
             do {
                 removeState.startLoading()
 
@@ -209,84 +237,244 @@ extension IAPModel {
             }
 
         case .fetchNotificationHistory(let startDate, let endDate, let transactionID):
-            guard !fetchNotificationHistoryState.isLoading,
-                let startDate = truncateSeconds(of: startDate),
-                let endDate = roundUpSeconds(of: endDate),
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value
-            else { return }
-            do {
-                fetchNotificationHistoryState.startLoading()
+            await fetchNotificationHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                replacesInFlightRequest: false,
+                appStoreServerClient: appStoreServerClient
+            )
 
-                // transactionId and notificationType are mutually exclusive in the API
-                let id = transactionID.isEmpty ? nil : transactionID
-                let filterOption = id == nil ? notificationFilterOption : nil
-                let failuresFilter = id == nil ? onlyFailuresFilter : nil
-
-                let request = NotificationHistoryRequest(
-                    startDate: startDate, endDate: endDate,
-                    notificationType: filterOption?.notificationType,
-                    notificationSubtype: filterOption?.subtype,
-                    transactionId: id, onlyFailures: failuresFilter)
-                let model = try await appStoreServerClient.fetchNotificationHistory(
-                    request: request, paginationToken: nil,
-                    credential: credential,
-                    rootCertificate: rootCertificate,
-                    environment: environment)
-                fetchNotificationHistoryState.finishLoading(model)
-            } catch {
-                fetchNotificationHistoryState.failLoading(
-                    with: IAPError.unknownError(message: error.localizedDescription))
-            }
+        case .reloadNotificationHistory(let startDate, let endDate, let transactionID):
+            await fetchNotificationHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                replacesInFlightRequest: true,
+                appStoreServerClient: appStoreServerClient
+            )
 
         case .appendFetchNotificationHistory(let startDate, let endDate, let transactionID):
-            guard !fetchNotificationHistoryState.isAppendLoading,
-                let startDate = truncateSeconds(of: startDate),
-                let endDate = roundUpSeconds(of: endDate),
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value,
-                let notificationHistory = fetchNotificationHistoryState.value
-            else { return }
-            do {
-                fetchNotificationHistoryState.startAppendLoading()
-
-                // transactionId and notificationType are mutually exclusive in the API
-                let id = transactionID.isEmpty ? nil : transactionID
-                let filterOption = id == nil ? notificationFilterOption : nil
-                let failuresFilter = id == nil ? onlyFailuresFilter : nil
-
-                let request = NotificationHistoryRequest(
-                    startDate: startDate, endDate: endDate,
-                    notificationType: filterOption?.notificationType,
-                    notificationSubtype: filterOption?.subtype,
-                    transactionId: id, onlyFailures: failuresFilter)
-                let model = try await appStoreServerClient.fetchNotificationHistory(
-                    request: request, paginationToken: notificationHistory.paginationToken,
-                    credential: credential, rootCertificate: rootCertificate,
-                    environment: environment)
-                let appendModel = NotificationHistoryModel(
-                    paginationToken: model.paginationToken, hasMore: model.hasMore,
-                    items: notificationHistory.items + model.items)
-                fetchNotificationHistoryState.finishAppendLoading(appendModel)
-            } catch {
-                fetchNotificationHistoryState.failAppendLoading(
-                    with: IAPError.unknownError(message: error.localizedDescription))
-            }
+            await appendFetchNotificationHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                loopCounts: 1,
+                appStoreServerClient: appStoreServerClient
+            )
 
         case .bulkAppendFetchNotificationHistory(let startDate, let endDate, let transactionID):
-            guard !fetchNotificationHistoryState.isAppendLoading,
-                let startDate = truncateSeconds(of: startDate),
-                let endDate = roundUpSeconds(of: endDate),
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value,
-                let notificationHistory = fetchNotificationHistoryState.value
-            else { return }
+            await appendFetchNotificationHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                loopCounts: 10,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .clearNotificationHistoryError:
+            fetchNotificationHistoryState.clearFailure()
+
+        case .fetchTransactionHistory(let startDate, let endDate, let transactionID):
+            await fetchTransactionHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                replacesInFlightRequest: false,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .reloadTransactionHistory(let startDate, let endDate, let transactionID):
+            await fetchTransactionHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                replacesInFlightRequest: true,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .appendFetchTransactionHistory(let startDate, let endDate, let transactionID):
+            await appendFetchTransactionHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                loopCounts: 1,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .bulkAppendFetchTransactionHistory(let startDate, let endDate, let transactionID):
+            await appendFetchTransactionHistory(
+                startDate: startDate,
+                endDate: endDate,
+                transactionID: transactionID,
+                loopCounts: 10,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .clearTransactionHistoryError:
+            fetchTransactionHistoryState.clearFailure()
+
+        case .fetchAllSubscriptionStatuses(let transactionID):
+            await fetchAllSubscriptionStatuses(
+                transactionID: transactionID,
+                replacesInFlightRequest: false,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .reloadAllSubscriptionStatuses(let transactionID):
+            await fetchAllSubscriptionStatuses(
+                transactionID: transactionID,
+                replacesInFlightRequest: true,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .clearAllSubscriptionStatusesError:
+            fetchAllSubscriptionStatusesState.clearFailure()
+
+        case .fetchTransactionInfo(let transactionID):
+            await fetchTransactionInfo(
+                transactionID: transactionID,
+                replacesInFlightRequest: false,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .reloadTransactionInfo(let transactionID):
+            await fetchTransactionInfo(
+                transactionID: transactionID,
+                replacesInFlightRequest: true,
+                appStoreServerClient: appStoreServerClient
+            )
+
+        case .clearTransactionInfoError:
+            fetchTransactionInfoState.clearFailure()
+        }
+    }
+}
+
+// MARK: - Loading Tasks
+
+extension IAPModel {
+
+    @MainActor
+    private func fetchNotificationHistory(
+        startDate: Date,
+        endDate: Date,
+        transactionID: String,
+        replacesInFlightRequest: Bool,
+        appStoreServerClient: AppStoreServerClient
+    ) async {
+        guard replacesInFlightRequest || !fetchNotificationHistoryState.isLoadingOrAppending else {
+            return
+        }
+
+        fetchNotificationHistoryGeneration += 1
+        let generation = fetchNotificationHistoryGeneration
+
+        fetchNotificationHistoryTask?.cancel()
+
+        guard
+            let startDate = truncateSeconds(of: startDate),
+            let endDate = roundUpSeconds(of: endDate),
+            let credential = credentialState.value,
+            let rootCertificate = rootCertificateState.value
+        else {
+            if replacesInFlightRequest {
+                fetchNotificationHistoryState.clear()
+            }
+            fetchNotificationHistoryTask = nil
+            return
+        }
+
+        fetchNotificationHistoryState.restartLoading()
+
+        // transactionId and notificationType are mutually exclusive in the API
+        let id = transactionID.isEmpty ? nil : transactionID
+        let filterOption = id == nil ? notificationFilterOption : nil
+        let failuresFilter = id == nil ? onlyFailuresFilter : nil
+        let request = NotificationHistoryRequest(
+            startDate: startDate,
+            endDate: endDate,
+            notificationType: filterOption?.notificationType,
+            notificationSubtype: filterOption?.subtype,
+            transactionId: id,
+            onlyFailures: failuresFilter
+        )
+        let environment = environment
+
+        let task = Task {
+            @MainActor [appStoreServerClient, request, credential, rootCertificate, environment] in
             do {
-                fetchNotificationHistoryState.startAppendLoading()
+                let model = try await appStoreServerClient.fetchNotificationHistory(
+                    request: request,
+                    paginationToken: nil,
+                    credential: credential,
+                    rootCertificate: rootCertificate,
+                    environment: environment
+                )
+                try Task.checkCancellation()
 
+                guard generation == fetchNotificationHistoryGeneration else { return }
+                fetchNotificationHistoryState.finishLoading(model)
+                fetchNotificationHistoryTask = nil
+            } catch is CancellationError {
+                guard generation == fetchNotificationHistoryGeneration else { return }
+                fetchNotificationHistoryState.clear()
+                fetchNotificationHistoryTask = nil
+            } catch {
+                guard generation == fetchNotificationHistoryGeneration else { return }
+                fetchNotificationHistoryState.failLoading(
+                    with: IAPError.unknownError(message: error.localizedDescription))
+                fetchNotificationHistoryTask = nil
+            }
+        }
+
+        fetchNotificationHistoryTask = task
+        await task.value
+    }
+
+    @MainActor
+    private func appendFetchNotificationHistory(
+        startDate: Date,
+        endDate: Date,
+        transactionID: String,
+        loopCounts: Int,
+        appStoreServerClient: AppStoreServerClient
+    ) async {
+        guard !fetchNotificationHistoryState.isLoadingOrAppending,
+            let startDate = truncateSeconds(of: startDate),
+            let endDate = roundUpSeconds(of: endDate),
+            let credential = credentialState.value,
+            let rootCertificate = rootCertificateState.value,
+            let notificationHistory = fetchNotificationHistoryState.value
+        else { return }
+
+        fetchNotificationHistoryGeneration += 1
+        let generation = fetchNotificationHistoryGeneration
+
+        fetchNotificationHistoryTask?.cancel()
+        fetchNotificationHistoryState.startAppendLoading()
+
+        // transactionId and notificationType are mutually exclusive in the API
+        let id = transactionID.isEmpty ? nil : transactionID
+        let filterOption = id == nil ? notificationFilterOption : nil
+        let failuresFilter = id == nil ? onlyFailuresFilter : nil
+        let request = NotificationHistoryRequest(
+            startDate: startDate,
+            endDate: endDate,
+            notificationType: filterOption?.notificationType,
+            notificationSubtype: filterOption?.subtype,
+            transactionId: id,
+            onlyFailures: failuresFilter
+        )
+        let environment = environment
+
+        let task = Task {
+            @MainActor [
+                appStoreServerClient, request, credential, rootCertificate, environment,
+                notificationHistory
+            ] in
+            do {
                 var merged = notificationHistory
-
-                let loopCounts = 10
 
                 for _ in 0 ..< loopCounts {
                     guard let hasMore = merged.hasMore, hasMore,
@@ -295,98 +483,141 @@ extension IAPModel {
                         break
                     }
 
-                    // transactionId and notificationType are mutually exclusive in the API
-                    let id = transactionID.isEmpty ? nil : transactionID
-                    let filterOption = id == nil ? notificationFilterOption : nil
-                    let failuresFilter = id == nil ? onlyFailuresFilter : nil
-
-                    let request = NotificationHistoryRequest(
-                        startDate: startDate, endDate: endDate,
-                        notificationType: filterOption?.notificationType,
-                        notificationSubtype: filterOption?.subtype,
-                        transactionId: id, onlyFailures: failuresFilter)
                     let model = try await appStoreServerClient.fetchNotificationHistory(
-                        request: request, paginationToken: paginationToken,
+                        request: request,
+                        paginationToken: paginationToken,
                         credential: credential,
                         rootCertificate: rootCertificate,
-                        environment: environment)
+                        environment: environment
+                    )
+                    try Task.checkCancellation()
 
                     merged = NotificationHistoryModel(
-                        paginationToken: model.paginationToken, hasMore: model.hasMore,
-                        items: merged.items + model.items)
+                        paginationToken: model.paginationToken,
+                        hasMore: model.hasMore,
+                        items: merged.items + model.items
+                    )
                 }
 
+                guard generation == fetchNotificationHistoryGeneration else { return }
                 fetchNotificationHistoryState.finishAppendLoading(merged)
+                fetchNotificationHistoryTask = nil
+            } catch is CancellationError {
+                guard generation == fetchNotificationHistoryGeneration else { return }
+                fetchNotificationHistoryState.finishAppendLoading(notificationHistory)
+                fetchNotificationHistoryTask = nil
             } catch {
+                guard generation == fetchNotificationHistoryGeneration else { return }
                 fetchNotificationHistoryState.failAppendLoading(
                     with: IAPError.unknownError(message: error.localizedDescription))
+                fetchNotificationHistoryTask = nil
             }
+        }
 
-        case .clearNotificationHistoryError:
-            fetchNotificationHistoryState.clear()
+        fetchNotificationHistoryTask = task
+        await task.value
+    }
 
-        case .fetchTransactionHistory(let startDate, let endDate, let transactionID):
-            guard !fetchTransactionHistoryState.isLoading,
-                let startDate = truncateSeconds(of: startDate),
-                let endDate = roundUpSeconds(of: endDate),
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value
-            else { return }
+    @MainActor
+    private func fetchTransactionHistory(
+        startDate: Date,
+        endDate: Date,
+        transactionID: String,
+        replacesInFlightRequest: Bool,
+        appStoreServerClient: AppStoreServerClient
+    ) async {
+        guard replacesInFlightRequest || !fetchTransactionHistoryState.isLoadingOrAppending else {
+            return
+        }
+
+        fetchTransactionHistoryGeneration += 1
+        let generation = fetchTransactionHistoryGeneration
+
+        fetchTransactionHistoryTask?.cancel()
+
+        guard !transactionID.isEmpty,
+            let startDate = truncateSeconds(of: startDate),
+            let endDate = roundUpSeconds(of: endDate),
+            let credential = credentialState.value,
+            let rootCertificate = rootCertificateState.value
+        else {
+            if replacesInFlightRequest {
+                fetchTransactionHistoryState.clear()
+            }
+            fetchTransactionHistoryTask = nil
+            return
+        }
+
+        fetchTransactionHistoryState.restartLoading()
+
+        let environment = environment
+        let task = Task {
+            @MainActor [
+                appStoreServerClient, startDate, endDate, transactionID, credential,
+                rootCertificate, environment
+            ] in
             do {
-                fetchTransactionHistoryState.startLoading()
-
                 let model = try await appStoreServerClient.fetchTransactionHistory(
-                    startDate: startDate, endDate: endDate, transactionID: transactionID,
+                    startDate: startDate,
+                    endDate: endDate,
+                    transactionID: transactionID,
                     revision: nil,
                     credential: credential,
                     rootCertificate: rootCertificate,
-                    environment: environment)
+                    environment: environment
+                )
+                try Task.checkCancellation()
+
+                guard generation == fetchTransactionHistoryGeneration else { return }
                 fetchTransactionHistoryState.finishLoading(model)
+                fetchTransactionHistoryTask = nil
+            } catch is CancellationError {
+                guard generation == fetchTransactionHistoryGeneration else { return }
+                fetchTransactionHistoryState.clear()
+                fetchTransactionHistoryTask = nil
             } catch {
+                guard generation == fetchTransactionHistoryGeneration else { return }
                 fetchTransactionHistoryState.failLoading(
                     with: IAPError.unknownError(message: error.localizedDescription))
+                fetchTransactionHistoryTask = nil
             }
+        }
 
-        case .appendFetchTransactionHistory(let startDate, let endDate, let transactionID):
-            guard !fetchTransactionHistoryState.isAppendLoading,
-                let startDate = truncateSeconds(of: startDate),
-                let endDate = roundUpSeconds(of: endDate),
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value,
-                let transactionHistory = fetchTransactionHistoryState.value
-            else { return }
+        fetchTransactionHistoryTask = task
+        await task.value
+    }
+
+    @MainActor
+    private func appendFetchTransactionHistory(
+        startDate: Date,
+        endDate: Date,
+        transactionID: String,
+        loopCounts: Int,
+        appStoreServerClient: AppStoreServerClient
+    ) async {
+        guard !fetchTransactionHistoryState.isLoadingOrAppending,
+            !transactionID.isEmpty,
+            let startDate = truncateSeconds(of: startDate),
+            let endDate = roundUpSeconds(of: endDate),
+            let credential = credentialState.value,
+            let rootCertificate = rootCertificateState.value,
+            let transactionHistory = fetchTransactionHistoryState.value
+        else { return }
+
+        fetchTransactionHistoryGeneration += 1
+        let generation = fetchTransactionHistoryGeneration
+
+        fetchTransactionHistoryTask?.cancel()
+        fetchTransactionHistoryState.startAppendLoading()
+
+        let environment = environment
+        let task = Task {
+            @MainActor [
+                appStoreServerClient, startDate, endDate, transactionID, credential,
+                rootCertificate, environment, transactionHistory
+            ] in
             do {
-                fetchTransactionHistoryState.startAppendLoading()
-
-                let model = try await appStoreServerClient.fetchTransactionHistory(
-                    startDate: startDate, endDate: endDate, transactionID: transactionID,
-                    revision: transactionHistory.revision, credential: credential,
-                    rootCertificate: rootCertificate,
-                    environment: environment)
-                let appendModel = TransactionHistory(
-                    revision: model.revision, hasMore: model.hasMore, bundleId: model.bundleId,
-                    appAppleId: model.appAppleId, environment: model.environment,
-                    items: transactionHistory.items + model.items)
-                fetchTransactionHistoryState.finishAppendLoading(appendModel)
-            } catch {
-                fetchTransactionHistoryState.failAppendLoading(
-                    with: IAPError.unknownError(message: error.localizedDescription))
-            }
-
-        case .bulkAppendFetchTransactionHistory(let startDate, let endDate, let transactionID):
-            guard !fetchTransactionHistoryState.isAppendLoading,
-                let startDate = truncateSeconds(of: startDate),
-                let endDate = roundUpSeconds(of: endDate),
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value,
-                let transactionHistory = fetchTransactionHistoryState.value
-            else { return }
-            do {
-                fetchTransactionHistoryState.startAppendLoading()
-
                 var merged = transactionHistory
-
-                let loopCounts = 10
 
                 for _ in 0 ..< loopCounts {
                     guard let hasMore = merged.hasMore, hasMore,
@@ -396,66 +627,164 @@ extension IAPModel {
                     }
 
                     let model = try await appStoreServerClient.fetchTransactionHistory(
-                        startDate: startDate, endDate: endDate, transactionID: transactionID,
-                        revision: revision, credential: credential,
+                        startDate: startDate,
+                        endDate: endDate,
+                        transactionID: transactionID,
+                        revision: revision,
+                        credential: credential,
                         rootCertificate: rootCertificate,
-                        environment: environment)
+                        environment: environment
+                    )
+                    try Task.checkCancellation()
 
                     merged = .init(
-                        revision: model.revision, hasMore: model.hasMore, bundleId: model.bundleId,
-                        appAppleId: model.appAppleId, environment: model.environment,
-                        items: merged.items + model.items)
+                        revision: model.revision,
+                        hasMore: model.hasMore,
+                        bundleId: model.bundleId,
+                        appAppleId: model.appAppleId,
+                        environment: model.environment,
+                        items: merged.items + model.items
+                    )
                 }
 
+                guard generation == fetchTransactionHistoryGeneration else { return }
                 fetchTransactionHistoryState.finishAppendLoading(merged)
+                fetchTransactionHistoryTask = nil
+            } catch is CancellationError {
+                guard generation == fetchTransactionHistoryGeneration else { return }
+                fetchTransactionHistoryState.finishAppendLoading(transactionHistory)
+                fetchTransactionHistoryTask = nil
             } catch {
+                guard generation == fetchTransactionHistoryGeneration else { return }
                 fetchTransactionHistoryState.failAppendLoading(
                     with: IAPError.unknownError(message: error.localizedDescription))
+                fetchTransactionHistoryTask = nil
             }
+        }
 
-        case .clearTransactionHistoryError:
-            fetchTransactionHistoryState.clear()
+        fetchTransactionHistoryTask = task
+        await task.value
+    }
 
-        case .fetchAllSubscriptionStatuses(let transactionID):
-            guard !fetchAllSubscriptionStatusesState.isAppendLoading,
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value
-            else { return }
+    @MainActor
+    private func fetchAllSubscriptionStatuses(
+        transactionID: String,
+        replacesInFlightRequest: Bool,
+        appStoreServerClient: AppStoreServerClient
+    ) async {
+        guard replacesInFlightRequest || !fetchAllSubscriptionStatusesState.isLoadingOrAppending
+        else { return }
+
+        fetchAllSubscriptionStatusesGeneration += 1
+        let generation = fetchAllSubscriptionStatusesGeneration
+
+        fetchAllSubscriptionStatusesTask?.cancel()
+
+        guard !transactionID.isEmpty,
+            let credential = credentialState.value,
+            let rootCertificate = rootCertificateState.value
+        else {
+            if replacesInFlightRequest {
+                fetchAllSubscriptionStatusesState.clear()
+            }
+            fetchAllSubscriptionStatusesTask = nil
+            return
+        }
+
+        fetchAllSubscriptionStatusesState.restartLoading()
+
+        let environment = environment
+        let task = Task {
+            @MainActor [
+                appStoreServerClient, transactionID, credential, rootCertificate, environment
+            ] in
             do {
-                fetchAllSubscriptionStatusesState.startLoading()
-
                 let model = try await appStoreServerClient.fetchAllSubscriptionStatuses(
-                    transactionID: transactionID, credential: credential,
-                    rootCertificate: rootCertificate, environment: environment)
+                    transactionID: transactionID,
+                    credential: credential,
+                    rootCertificate: rootCertificate,
+                    environment: environment
+                )
+                try Task.checkCancellation()
+
+                guard generation == fetchAllSubscriptionStatusesGeneration else { return }
                 fetchAllSubscriptionStatusesState.finishLoading(model)
+                fetchAllSubscriptionStatusesTask = nil
+            } catch is CancellationError {
+                guard generation == fetchAllSubscriptionStatusesGeneration else { return }
+                fetchAllSubscriptionStatusesState.clear()
+                fetchAllSubscriptionStatusesTask = nil
             } catch {
+                guard generation == fetchAllSubscriptionStatusesGeneration else { return }
                 fetchAllSubscriptionStatusesState.failLoading(
                     with: IAPError.unknownError(message: error.localizedDescription))
+                fetchAllSubscriptionStatusesTask = nil
             }
+        }
 
-        case .clearAllSubscriptionStatusesError:
-            fetchAllSubscriptionStatusesState.clear()
+        fetchAllSubscriptionStatusesTask = task
+        await task.value
+    }
 
-        case .fetchTransactionInfo(let transactionID):
-            guard !fetchTransactionInfoState.isLoading,
-                let credential = credentialState.value,
-                let rootCertificate = rootCertificateState.value
-            else { return }
+    @MainActor
+    private func fetchTransactionInfo(
+        transactionID: String,
+        replacesInFlightRequest: Bool,
+        appStoreServerClient: AppStoreServerClient
+    ) async {
+        guard replacesInFlightRequest || !fetchTransactionInfoState.isLoadingOrAppending else {
+            return
+        }
+
+        fetchTransactionInfoGeneration += 1
+        let generation = fetchTransactionInfoGeneration
+
+        fetchTransactionInfoTask?.cancel()
+
+        guard !transactionID.isEmpty,
+            let credential = credentialState.value,
+            let rootCertificate = rootCertificateState.value
+        else {
+            if replacesInFlightRequest {
+                fetchTransactionInfoState.clear()
+            }
+            fetchTransactionInfoTask = nil
+            return
+        }
+
+        fetchTransactionInfoState.restartLoading()
+
+        let environment = environment
+        let task = Task {
+            @MainActor [
+                appStoreServerClient, transactionID, credential, rootCertificate, environment
+            ] in
             do {
-                fetchTransactionInfoState.startLoading()
-
                 let model = try await appStoreServerClient.fetchTransactionInfo(
-                    transactionID: transactionID, credential: credential,
-                    rootCertificate: rootCertificate, environment: environment)
+                    transactionID: transactionID,
+                    credential: credential,
+                    rootCertificate: rootCertificate,
+                    environment: environment
+                )
+                try Task.checkCancellation()
+
+                guard generation == fetchTransactionInfoGeneration else { return }
                 fetchTransactionInfoState.finishLoading(model)
+                fetchTransactionInfoTask = nil
+            } catch is CancellationError {
+                guard generation == fetchTransactionInfoGeneration else { return }
+                fetchTransactionInfoState.clear()
+                fetchTransactionInfoTask = nil
             } catch {
+                guard generation == fetchTransactionInfoGeneration else { return }
                 fetchTransactionInfoState.failLoading(
                     with: IAPError.unknownError(message: error.localizedDescription))
+                fetchTransactionInfoTask = nil
             }
-
-        case .clearTransactionInfoError:
-            fetchTransactionInfoState.clear()
         }
+
+        fetchTransactionInfoTask = task
+        await task.value
     }
 }
 

--- a/Sources/IAPModel/LoadingViewState.swift
+++ b/Sources/IAPModel/LoadingViewState.swift
@@ -37,6 +37,15 @@ public enum LoadingViewState<Element: Equatable>: Equatable {
         return true
     }
 
+    public var isLoadingOrAppending: Bool {
+        switch self {
+        case .loading, .appendLoading:
+            true
+        case .waiting, .success, .failed:
+            false
+        }
+    }
+
     public var presentsError: IAPError? {
         get {
             guard case .failed(let error) = self else { return nil }
@@ -53,6 +62,10 @@ public enum LoadingViewState<Element: Equatable>: Equatable {
             assertionFailure()
             return
         }
+    }
+
+    public mutating func restartLoading() {
+        self = .loading
     }
 
     public mutating func finishLoading(_ element: Element) {
@@ -72,6 +85,11 @@ public enum LoadingViewState<Element: Equatable>: Equatable {
     }
 
     public mutating func clear() {
+        self = .waiting
+    }
+
+    public mutating func clearFailure() {
+        guard case .failed = self else { return }
         self = .waiting
     }
 

--- a/Sources/IAPView/NotificationHistoryView.swift
+++ b/Sources/IAPView/NotificationHistoryView.swift
@@ -40,19 +40,31 @@ struct NotificationHistoryView: View {
             }
             .onChange(of: model.environment) { _, _ in
                 Task {
-                    await model.execute(action: .clearNotificationHistoryError)
+                    await model.execute(
+                        action: .reloadNotificationHistory(
+                            startDate: model.notificationStartDate,
+                            endDate: model.notificationEndDate,
+                            transactionID: model.notificationHistoryTransactionID))
                 }
             }
             .onChange(of: model.notificationFilterOption) { oldValue, newValue in
                 guard oldValue != newValue else { return }
                 Task {
-                    await model.execute(action: .clearNotificationHistoryError)
+                    await model.execute(
+                        action: .reloadNotificationHistory(
+                            startDate: model.notificationStartDate,
+                            endDate: model.notificationEndDate,
+                            transactionID: model.notificationHistoryTransactionID))
                 }
             }
             .onChange(of: model.onlyFailuresFilter) { oldValue, newValue in
                 guard oldValue != newValue else { return }
                 Task {
-                    await model.execute(action: .clearNotificationHistoryError)
+                    await model.execute(
+                        action: .reloadNotificationHistory(
+                            startDate: model.notificationStartDate,
+                            endDate: model.notificationEndDate,
+                            transactionID: model.notificationHistoryTransactionID))
                 }
             }
             .onChange(of: [
@@ -65,7 +77,11 @@ struct NotificationHistoryView: View {
             .onSubmit {
                 Task {
                     model.isNotificationHistoryStaledParameters = false
-                    await model.execute(action: .clearNotificationHistoryError)
+                    await model.execute(
+                        action: .reloadNotificationHistory(
+                            startDate: model.notificationStartDate,
+                            endDate: model.notificationEndDate,
+                            transactionID: model.notificationHistoryTransactionID))
                 }
             }
             .textSelection(.enabled)
@@ -98,7 +114,11 @@ struct NotificationHistoryView: View {
                         Text("\(error.localizedDescription)")
                         Button("Retry") {
                             Task {
-                                await model.execute(action: .clearNotificationHistoryError)
+                                await model.execute(
+                                    action: .reloadNotificationHistory(
+                                        startDate: model.notificationStartDate,
+                                        endDate: model.notificationEndDate,
+                                        transactionID: model.notificationHistoryTransactionID))
                             }
                         }
                     }
@@ -269,7 +289,12 @@ struct NotificationHistoryView: View {
             Button {
                 Task {
                     bindableModel.wrappedValue.isNotificationHistoryStaledParameters = false
-                    await bindableModel.wrappedValue.execute(action: .clearNotificationHistoryError)
+                    await bindableModel.wrappedValue.execute(
+                        action: .reloadNotificationHistory(
+                            startDate: bindableModel.wrappedValue.notificationStartDate,
+                            endDate: bindableModel.wrappedValue.notificationEndDate,
+                            transactionID: bindableModel.wrappedValue
+                                .notificationHistoryTransactionID))
                 }
             } label: {
                 Image(systemName: "arrow.counterclockwise")

--- a/Sources/IAPView/SubscriptionStatusView.swift
+++ b/Sources/IAPView/SubscriptionStatusView.swift
@@ -40,7 +40,8 @@ struct SubscriptionStatusView: View {
             }
             .onChange(of: model.environment) { _, _ in
                 Task {
-                    await model.execute(action: .clearAllSubscriptionStatusesError)
+                    await model.execute(
+                        action: .reloadAllSubscriptionStatuses(transactionID: model.transactionID))
                 }
             }
             .onChange(of: model.transactionID) { (oldValue, newValue) in
@@ -50,7 +51,8 @@ struct SubscriptionStatusView: View {
             .onSubmit {
                 Task {
                     model.isStaledParameters = false
-                    await model.execute(action: .clearAllSubscriptionStatusesError)
+                    await model.execute(
+                        action: .reloadAllSubscriptionStatuses(transactionID: model.transactionID))
                 }
             }
             .textSelection(.enabled)
@@ -83,7 +85,9 @@ struct SubscriptionStatusView: View {
                         Text("\(error.localizedDescription)")
                         Button("Retry") {
                             Task {
-                                await model.execute(action: .clearAllSubscriptionStatusesError)
+                                await model.execute(
+                                    action: .reloadAllSubscriptionStatuses(
+                                        transactionID: model.transactionID))
                             }
                         }
                     }
@@ -135,7 +139,8 @@ struct SubscriptionStatusView: View {
                 Task {
                     bindableModel.wrappedValue.isStaledParameters = false
                     await bindableModel.wrappedValue.execute(
-                        action: .clearAllSubscriptionStatusesError)
+                        action: .reloadAllSubscriptionStatuses(
+                            transactionID: bindableModel.wrappedValue.transactionID))
                 }
             } label: {
                 Image(systemName: "arrow.counterclockwise")

--- a/Sources/IAPView/TransactionHistoryView.swift
+++ b/Sources/IAPView/TransactionHistoryView.swift
@@ -40,7 +40,11 @@ struct TransactionHistoryView: View {
             }
             .onChange(of: model.environment) { _, _ in
                 Task {
-                    await model.execute(action: .clearTransactionHistoryError)
+                    await model.execute(
+                        action: .reloadTransactionHistory(
+                            startDate: model.transactionStartDate,
+                            endDate: model.transactionEndDate,
+                            transactionID: model.transactionID))
                 }
             }
             .onChange(of: model.transactionID) { (oldValue, newValue) in
@@ -55,7 +59,11 @@ struct TransactionHistoryView: View {
             .onSubmit {
                 Task {
                     model.isStaledParameters = false
-                    await model.execute(action: .clearTransactionHistoryError)
+                    await model.execute(
+                        action: .reloadTransactionHistory(
+                            startDate: model.transactionStartDate,
+                            endDate: model.transactionEndDate,
+                            transactionID: model.transactionID))
                 }
             }
             .textSelection(.enabled)
@@ -88,7 +96,11 @@ struct TransactionHistoryView: View {
                         Text("\(error.localizedDescription)")
                         Button("Retry") {
                             Task {
-                                await model.execute(action: .clearTransactionHistoryError)
+                                await model.execute(
+                                    action: .reloadTransactionHistory(
+                                        startDate: model.transactionStartDate,
+                                        endDate: model.transactionEndDate,
+                                        transactionID: model.transactionID))
                             }
                         }
                     }
@@ -211,7 +223,11 @@ struct TransactionHistoryView: View {
             Button {
                 Task {
                     bindableModel.wrappedValue.isStaledParameters = false
-                    await bindableModel.wrappedValue.execute(action: .clearTransactionHistoryError)
+                    await bindableModel.wrappedValue.execute(
+                        action: .reloadTransactionHistory(
+                            startDate: bindableModel.wrappedValue.transactionStartDate,
+                            endDate: bindableModel.wrappedValue.transactionEndDate,
+                            transactionID: bindableModel.wrappedValue.transactionID))
                 }
             } label: {
                 Image(systemName: "arrow.counterclockwise")

--- a/Sources/IAPView/TransactionInfoView.swift
+++ b/Sources/IAPView/TransactionInfoView.swift
@@ -40,7 +40,9 @@ struct TransactionInfoView: View {
             }
             .onChange(of: model.environment) { _, _ in
                 Task {
-                    await model.execute(action: .clearTransactionInfoError)
+                    await model.execute(
+                        action: .reloadTransactionInfo(
+                            transactionID: model.transactionInfoTransactionID))
                 }
             }
             .onChange(of: model.transactionInfoTransactionID) { (oldValue, newValue) in
@@ -50,7 +52,9 @@ struct TransactionInfoView: View {
             .onSubmit {
                 Task {
                     model.isTransactionInfoStaledParameters = false
-                    await model.execute(action: .clearTransactionInfoError)
+                    await model.execute(
+                        action: .reloadTransactionInfo(
+                            transactionID: model.transactionInfoTransactionID))
                 }
             }
             .textSelection(.enabled)
@@ -83,7 +87,9 @@ struct TransactionInfoView: View {
                         Text("\(error.localizedDescription)")
                         Button("Retry") {
                             Task {
-                                await model.execute(action: .clearTransactionInfoError)
+                                await model.execute(
+                                    action: .reloadTransactionInfo(
+                                        transactionID: model.transactionInfoTransactionID))
                             }
                         }
                     }
@@ -133,7 +139,10 @@ struct TransactionInfoView: View {
             Button {
                 Task {
                     bindableModel.wrappedValue.isTransactionInfoStaledParameters = false
-                    await bindableModel.wrappedValue.execute(action: .clearTransactionInfoError)
+                    await bindableModel.wrappedValue.execute(
+                        action: .reloadTransactionInfo(
+                            transactionID: bindableModel.wrappedValue
+                                .transactionInfoTransactionID))
                 }
             } label: {
                 Image(systemName: "arrow.counterclockwise")

--- a/Tests/IAPModelTests/IAPModelTests.swift
+++ b/Tests/IAPModelTests/IAPModelTests.swift
@@ -6,22 +6,25 @@
 //
 
 import Dependencies
+import Foundation
 import IAPInterface
-import XCTest
+import Testing
 
 @testable import IAPModel
 
-final class IAPModelTests: XCTestCase {
+struct IAPModelTests {
 
+    @Test
     func testLoadingViewStateIsLoadingOrAppending() {
-        XCTAssertFalse(LoadingViewState<Int>.waiting.isLoadingOrAppending)
-        XCTAssertTrue(LoadingViewState<Int>.loading.isLoadingOrAppending)
-        XCTAssertTrue(LoadingViewState<Int>.appendLoading(1).isLoadingOrAppending)
-        XCTAssertFalse(LoadingViewState<Int>.success(1).isLoadingOrAppending)
-        XCTAssertFalse(
-            LoadingViewState<Int>.failed(.unknownError(message: nil)).isLoadingOrAppending)
+        #expect(!LoadingViewState<Int>.waiting.isLoadingOrAppending)
+        #expect(LoadingViewState<Int>.loading.isLoadingOrAppending)
+        #expect(LoadingViewState<Int>.appendLoading(1).isLoadingOrAppending)
+        #expect(!LoadingViewState<Int>.success(1).isLoadingOrAppending)
+        #expect(
+            !LoadingViewState<Int>.failed(.unknownError(message: nil)).isLoadingOrAppending)
     }
 
+    @Test
     @MainActor
     func testReloadNotificationHistoryPrioritizesLatestRequest() async {
         let credential = IAPEnvironment(
@@ -88,7 +91,7 @@ final class IAPModelTests: XCTestCase {
             }
 
             await fetchCoordinator.waitForFirstStarted()
-            XCTAssertTrue(model.fetchNotificationHistoryState.isLoadingOrAppending)
+            #expect(model.fetchNotificationHistoryState.isLoadingOrAppending)
 
             let secondFetchTask = Task {
                 await model.execute(
@@ -104,14 +107,14 @@ final class IAPModelTests: XCTestCase {
             await fetchCoordinator.finishSecond()
             await secondFetchTask.value
 
-            XCTAssertEqual(model.fetchNotificationHistoryState.value, secondResponse)
+            #expect(model.fetchNotificationHistoryState.value == secondResponse)
 
             await fetchCoordinator.finishFirst()
             await firstFetchTask.value
 
-            XCTAssertEqual(model.fetchNotificationHistoryState.value, secondResponse)
+            #expect(model.fetchNotificationHistoryState.value == secondResponse)
             let numberOfCalls = await fetchCoordinator.numberOfCalls()
-            XCTAssertEqual(numberOfCalls, 2)
+            #expect(numberOfCalls == 2)
         }
     }
 }

--- a/Tests/IAPModelTests/IAPModelTests.swift
+++ b/Tests/IAPModelTests/IAPModelTests.swift
@@ -5,11 +5,174 @@
 //  Created by Go TAKAGI on 2024/03/03.
 //
 
+import Dependencies
+import IAPInterface
 import XCTest
 
 @testable import IAPModel
 
 final class IAPModelTests: XCTestCase {
 
-    func testExample() throws {}
+    func testLoadingViewStateIsLoadingOrAppending() {
+        XCTAssertFalse(LoadingViewState<Int>.waiting.isLoadingOrAppending)
+        XCTAssertTrue(LoadingViewState<Int>.loading.isLoadingOrAppending)
+        XCTAssertTrue(LoadingViewState<Int>.appendLoading(1).isLoadingOrAppending)
+        XCTAssertFalse(LoadingViewState<Int>.success(1).isLoadingOrAppending)
+        XCTAssertFalse(
+            LoadingViewState<Int>.failed(.unknownError(message: nil)).isLoadingOrAppending)
+    }
+
+    @MainActor
+    func testReloadNotificationHistoryPrioritizesLatestRequest() async {
+        let credential = IAPEnvironment(
+            bundleID: "com.example.app",
+            issuerID: "issuer-id",
+            keyID: "key-id",
+            appAppleID: 1_234_567_890,
+            encodedKey: "private-key"
+        )
+        let firstResponse = NotificationHistoryModel(
+            paginationToken: "first",
+            hasMore: false,
+            items: []
+        )
+        let secondResponse = NotificationHistoryModel(
+            paginationToken: "second",
+            hasMore: false,
+            items: []
+        )
+        let fetchCoordinator = NotificationHistoryFetchCoordinator(
+            firstResponse: firstResponse,
+            secondResponse: secondResponse
+        )
+
+        await withDependencies {
+            $0.calendar = Calendar(identifier: .gregorian)
+            $0[CredentialClient.self] = .init(
+                get: { credential },
+                set: { _, _, _, _, _ in },
+                remove: {}
+            )
+            $0[RootCertificateClient.self] = .init(
+                fetch: { Data() },
+                get: { Data([0x01]) },
+                remove: {}
+            )
+            $0[AppStoreServerClient.self] = .init(
+                fetchNotificationHistory: { _, _, _, _, _ in
+                    await fetchCoordinator.fetch()
+                },
+                fetchTransactionHistory: { _, _, _, _, _, _, _ in
+                    throw CancellationError()
+                },
+                fetchAllSubscriptionStatuses: { _, _, _, _ in
+                    throw CancellationError()
+                },
+                fetchTransactionInfo: { _, _, _, _ in
+                    throw CancellationError()
+                }
+            )
+        } operation: {
+            let model = IAPModel()
+            await model.execute(action: .getCredential)
+            await model.execute(action: .getRootCertificate)
+
+            let firstFetchTask = Task {
+                await model.execute(
+                    action: .reloadNotificationHistory(
+                        startDate: Date(timeIntervalSince1970: 0),
+                        endDate: Date(timeIntervalSince1970: 60),
+                        transactionID: ""
+                    )
+                )
+            }
+
+            await fetchCoordinator.waitForFirstStarted()
+            XCTAssertTrue(model.fetchNotificationHistoryState.isLoadingOrAppending)
+
+            let secondFetchTask = Task {
+                await model.execute(
+                    action: .reloadNotificationHistory(
+                        startDate: Date(timeIntervalSince1970: 60),
+                        endDate: Date(timeIntervalSince1970: 120),
+                        transactionID: ""
+                    )
+                )
+            }
+
+            await fetchCoordinator.waitForSecondStarted()
+            await fetchCoordinator.finishSecond()
+            await secondFetchTask.value
+
+            XCTAssertEqual(model.fetchNotificationHistoryState.value, secondResponse)
+
+            await fetchCoordinator.finishFirst()
+            await firstFetchTask.value
+
+            XCTAssertEqual(model.fetchNotificationHistoryState.value, secondResponse)
+            let numberOfCalls = await fetchCoordinator.numberOfCalls()
+            XCTAssertEqual(numberOfCalls, 2)
+        }
+    }
+}
+
+private actor NotificationHistoryFetchCoordinator {
+    private let firstResponse: NotificationHistoryModel
+    private let secondResponse: NotificationHistoryModel
+
+    private let firstStarted = AsyncStream<Void>.makeStream(of: Void.self)
+    private let secondStarted = AsyncStream<Void>.makeStream(of: Void.self)
+    private let firstFinished = AsyncStream<Void>.makeStream(of: Void.self)
+    private let secondFinished = AsyncStream<Void>.makeStream(of: Void.self)
+
+    private var callCount = 0
+
+    init(firstResponse: NotificationHistoryModel, secondResponse: NotificationHistoryModel) {
+        self.firstResponse = firstResponse
+        self.secondResponse = secondResponse
+    }
+
+    func fetch() async -> NotificationHistoryModel {
+        callCount += 1
+
+        switch callCount {
+        case 1:
+            firstStarted.continuation.yield()
+            await waitUntilFinished(firstFinished.stream)
+            return firstResponse
+        case 2:
+            secondStarted.continuation.yield()
+            await waitUntilFinished(secondFinished.stream)
+            return secondResponse
+        default:
+            return secondResponse
+        }
+    }
+
+    func waitForFirstStarted() async {
+        await waitUntilFinished(firstStarted.stream)
+    }
+
+    func waitForSecondStarted() async {
+        await waitUntilFinished(secondStarted.stream)
+    }
+
+    func finishFirst() {
+        firstFinished.continuation.yield()
+        firstFinished.continuation.finish()
+    }
+
+    func finishSecond() {
+        secondFinished.continuation.yield()
+        secondFinished.continuation.finish()
+    }
+
+    func numberOfCalls() -> Int {
+        callCount
+    }
+
+    private func waitUntilFinished(_ stream: AsyncStream<Void>) async {
+        var iterator = stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
 }


### PR DESCRIPTION
## Summary

This PR refines the loading state flow so user-driven reloads take precedence over in-flight App Store Server API requests.

## Root cause

The previous flow used clear...Error actions to reset list state back to .waiting, which indirectly caused SwiftUI .task handlers to start a new fetch. That mixed two separate responsibilities: dismissing failed state and invalidating/reloading data. When a request was already in flight, loading guards could either ignore a user-driven reload or allow an older request to finish into a state that had already been reset.

## Changes

- Adds explicit reload actions for notification history, transaction history, subscription status, and transaction info.
- Tracks per-feature request tasks and generation counters in IAPModel.
- Keeps initial fetch and append fetch mutually exclusive within each feature state.
- Allows reload actions to cancel in-flight work and start the latest request immediately.
- Discards stale completions when an older async request returns after a newer reload.
- Narrows clear...Error actions to failed-state dismissal instead of reload orchestration.
- Adds LoadingViewState helpers for combined loading checks, forced reload loading, and failed-state clearing.
- Updates SwiftUI environment, retry, submit, and filter-change flows to dispatch reload actions directly.
- Normalizes @Sendable closure declaration formatting in affected dependency client interfaces.

## User impact

Reload, environment changes, date changes, and transaction ID changes now prioritize the user's latest intent instead of being dropped because an earlier request is still loading. Older responses no longer overwrite the newest visible request state.

## Validation

- swift test
- Added a model test that simulates an older notification history request completing after a newer reload and verifies that only the newer result remains visible.